### PR TITLE
change package name to rubicon-ml to match pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
 }
 
 setup(
-    name="rubicon",
+    name="rubicon-ml",
     version="0.1.0",
     author="Joe Wolfe, Ryan Soley, Diane Lee, Mike McCarty, CapitalOne",
     license='Apache License, Version 2.0',


### PR DESCRIPTION
## What
  * Updating package name to match https://pypi.org/project/rubicon-ml/