### PR TITLE
GitHub pages workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,9 +3,12 @@
 # For more details: https://github.com/marketplace/actions/deploy-to-github-pages
 name: Publish docs
 
+# on:
+#   release:
+#     types: [created]
 on:
-  release:
-    types: [created]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,6 +28,8 @@ jobs:
         conda env update --file docs/docs-environment.yml --name base
     - name: Build
       run: |
+        pwd
+        ls -lta 
         cd docs
         sh build-docs.sh
     - name: Publish

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,7 +30,6 @@ jobs:
       run: |
         cd docs
         sh build-docs.sh
-      shell: bash
     - name: Publish
       uses: JamesIves/github-pages-deploy-action@4.0.0
       with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,34 @@
+# This workflow builds and publishes the latest docs to
+# the `gh-pages` branch.
+# For more details: https://github.com/marketplace/actions/deploy-to-github-pages
+name: Publish docs
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda env update --file docs/docs-environment.yml --name base
+    - name: Build
+      run: |
+        cd docs
+        sh build-docs.sh
+    - name: Publish
+      uses: JamesIves/github-pages-deploy-action@4.0.0
+      with:
+        branch: gh-pages
+        folder: build/html

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,4 +34,4 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@4.0.0
       with:
         branch: gh-pages
-        folder: build/html
+        folder: docs/build/html

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ main ]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,12 +3,9 @@
 # For more details: https://github.com/marketplace/actions/deploy-to-github-pages
 name: Publish docs
 
-# on:
-#   release:
-#     types: [created]
 on:
-  pull_request:
-    branches: [ main ]
+  release:
+    types: [created]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,10 +10,6 @@ on:
   pull_request:
     branches: [ main ]
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -34,6 +30,7 @@ jobs:
       run: |
         cd docs
         sh build-docs.sh
+      shell: bash
     - name: Publish
       uses: JamesIves/github-pages-deploy-action@4.0.0
       with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,8 +28,6 @@ jobs:
         conda env update --file docs/docs-environment.yml --name base
     - name: Build
       run: |
-        pwd
-        ls -lta 
         cd docs
         sh build-docs.sh
     - name: Publish

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,8 @@
-name: Publish python package
+# This workflow publishes the package to pypi.
+#
+# For more details: 
+# https://docs.github.com/en/actions/guides/building-and-testing-python#publishing-to-package-registries
+name: Publish
 
 on:
   release:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,6 +1,5 @@
 # This workflow publishes the package to pypi.
-#
-# For more details: 
+# For more details:
 # https://docs.github.com/en/actions/guides/building-and-testing-python#publishing-to-package-registries
 name: Publish
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,6 +1,5 @@
 # This workflow installs the package dependencies, lints the package, and
 # executes the package tests.
-#
 # For more details: https://docs.github.com/en/actions/guides/building-and-testing-python
 name: Run tests
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -2,7 +2,7 @@
 # executes the package tests.
 #
 # For more details: https://docs.github.com/en/actions/guides/building-and-testing-python
-name: Tests
+name: Run tests
 
 on:
   pull_request:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,7 +6,8 @@ dependencies:
   - pip
 
   - click>=7.1
-  - dask[dataframe]>=2.12.0
+  - dask>=2.12.0
+  - pandas>=1.0
   - fsspec=0.8.3
   - intake>=0.5.2
   - pyarrow>=0.16.0,<0.18.0

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 
-if [[ $(pwd) =~ .*/rubicon/docs$ ]]; then
-    if [ "$1" != "--no-clone" ]; then
-        rm -rf build
-        mkdir build
-        cd build
-        git clone -b gh-pages https://github.com/capitalone/rubicon.git html
-        cd ..
-    else
-        rm -rf build/html
-        mkdir build/html
-    fi
-    make html
-    open build/html/index.html
-    echo "Opening $(pwd)/build/html/index.html..."
+echo "Run 'build-docs.sh' from rubicon/docs"
+
+if [ "$1" != "--no-clone" ]; then
+    rm -rf build
+    mkdir build
+    cd build
+    git clone -b gh-pages https://github.com/capitalone/rubicon.git html
+    cd ..
 else
-    echo "'build-docs.sh' must be run from rubicon/docs"
+    rm -rf build/html
+    mkdir build/html
 fi
+make html
+open build/html/index.html
+echo "Opening $(pwd)/build/html/index.html..."

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [[ $(pwd) =~ .*/rubicon/docs$ ]]; then
     if [ "$1" != "--no-clone" ]; then
         rm -rf build


### PR DESCRIPTION
## What

Adds a github action workflow to automatically build and publish the latest docs. The `build-docs.sh` script used bash syntax for regex matching but I couldn't get it to run on github actions. Looks like the default shell there is `/bin/sh` and even with following the steps to update shell [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-running-a-script-using-bash), it still failed to execute the script. So for now i took out the regex check

## How to Test

Using github actions to test
* https://github.com/capitalone/rubicon/commit/b57132b9bf74aab4df501d341cb9a2fc29b0adbd
* https://github.com/capitalone/rubicon/pull/15/checks?check_run_id=2005494964
