### PR TITLE
handle comparison view with no params or metrics

### DIFF
--- a/rubicon/ui/views/project_explorer.py
+++ b/rubicon/ui/views/project_explorer.py
@@ -205,6 +205,7 @@ def _get_comparison_layout(id, rubicon_model, commit_hash):
     )
 
     anchor_options = rubicon_model.get_anchor_options(commit_hash)
+    anchor_value = anchor_options[-1]["value"] if len(anchor_options) > 0 else ""
 
     anchor_dropdown = dcc.Dropdown(
         id={"type": "anchor-dropdown", "index": id},
@@ -212,7 +213,7 @@ def _get_comparison_layout(id, rubicon_model, commit_hash):
         placeholder="Select an anchor metric",
         clearable=False,
         options=anchor_options,
-        value=anchor_options[-1]["value"],
+        value=anchor_value,
     )
 
     return html.Div([experiment_comparison_header, anchor_dropdown, experiment_comparison_plot])

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -166,6 +166,22 @@ def dashboard_setup(rubicon_and_project_client_with_experiments):
 
     return dashboard
 
+@pytest.fixture
+def dashboard_setup_without_parameters_or_metrics(rubicon_and_project_client):
+    """Setup an instance of the rubicon dashboard with a default project and
+    the bare minimum experiment data.
+    """
+    from rubicon.ui.dashboard import Dashboard
+
+    rubicon, project = rubicon_and_project_client
+
+    for i in range(0, 3):
+        project.log_experiment(f"exp-{i}")
+    
+    dashboard = Dashboard(rubicon.config.persistence, rubicon.config.root_dir)
+
+    return dashboard
+
 
 @pytest.fixture
 def test_dataframe():

--- a/tests/integration/test_dashboard.py
+++ b/tests/integration/test_dashboard.py
@@ -44,6 +44,31 @@ def test_refresh_projects(dashboard_setup, dash_duo):
     assert len(project_options) == 2
     assert project_options[0].text == project.name
 
+@pytest.mark.dashboard_test
+def test_dashboard_project_view_without_metrics_and_parameters(dashboard_setup_without_parameters_or_metrics, dash_duo):
+    dash_duo.start_server(dashboard_setup_without_parameters_or_metrics._app)
+
+    project_selection_list = dash_duo.find_element("#project-selection--list")
+    project_options = project_selection_list.find_elements_by_class_name(
+        "project-selection--project"
+    )
+    first_project = project_options[0]
+    first_project.click()
+
+    dash_duo.wait_for_element("#grouped-project-explorer", timeout=3)
+
+    # check the experiments view
+    group_project_explorer = dash_duo.find_element("#grouped-project-explorer")
+    assert group_project_explorer
+
+    experiment_details_header = group_project_explorer.find_element_by_id(
+        "experiment-deatils-header"
+    )
+    assert experiment_details_header.text == "Test Project"
+
+    # the project is seeded with 1 different groupings based on commit
+    assert len(group_project_explorer.find_elements_by_class_name("group-preview-row")) == 1
+
 
 @pytest.mark.dashboard_test
 def test_select_project_view(dashboard_setup, dash_duo):


### PR DESCRIPTION
**closes: #11**

---

## What

If a project's experiments did not have any metrics or parameters logged to them yet, the dashboard could not load the project data properly. This PR handles that case and adds a test against it.

## How to Test

`pytest -m "dashboard_test"`
