### PR TITLE
add PyPi long description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Rubicon
+# Rubicon
 
 [![PyPi Version](https://img.shields.io/pypi/v/rubicon_ml.svg)](https://pypi.org/project/rubicon-ml/)
 [![Test Package](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Rubicon
+<p align="center">
+  <img src="docs/source/_static/images/rubicon_logo_black.png">
+</p>
+
+---
 
 `rubicon` is a data science tool for capturing all information related to a model during its development. With minimal effort, Rubicon's Python library can integrate directly into your Python models:
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 from rubicon import Rubicon
 
 # Configure client object, automatically track git details
-rubicon = Rubicon(persistence="filesystem", root_dir="/rubicon-root", auto_git_enabled=True)
+rubicon = Rubicon(
+    persistence="filesystem", root_dir="/rubicon-root", auto_git_enabled=True
+)
 
 # Create a project to hold a collection of experiments
-project = rubicon.create_project("Hello World", description="Using rubicon to track model results over time.")
+project = rubicon.create_project(
+    "Hello World", description="Using rubicon to track model results over time."
+)
 
 # Log experiment data
 experiment = project.log_experiment(

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-<p align="center">
-  <img src="docs/source/_static/images/rubicon_logo_black.png">
-</p>
+## Rubicon
 
----
+[![PyPi Version](https://img.shields.io/pypi/v/rubicon_ml.svg)](https://pypi.org/project/rubicon-ml/)
+[![Test Package](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml)
+[![Publish Package](https://github.com/capitalone/rubicon/actions/workflows/publish-package.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/publish-package.yml)
+[![Publish Docs](https://github.com/capitalone/rubicon/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/publish-docs.yml)
 
-`rubicon` is a data science tool for capturing all information related to a model during its development. With minimal effort, Rubicon's Python library can integrate directly into your Python models:
+`rubicon` is a data science tool for capturing all information related to a model
+during its development. With minimal effort, Rubicon's Python library can integrate
+directly into your Python models:
 
 ```python
 from rubicon import Rubicon
@@ -139,8 +142,11 @@ code format throughout the project. You can format without committing via
     width="100px;" alt=""/><br /><sub><b>Mike McCarty</b></sub></a><br /></td>
     <td align="center"><a href="https://github.com/srilatharanganathan"><img src="https://avatars.githubusercontent.com/u/31327886?v=4"
     width="100px;" alt=""/><br /><sub><b>Sri Ranganathan</b></sub></a><br /></td>
-    <td align="center"><a href="https://github.com/joe-wolfe21"><img src="https://avatars.githubusercontent.com/u/10947704?v=4" width="100px;" alt=""/><br /><sub><b>Joe Wolfe</b></sub></a><br /></td>
-    <td align="center"><a href="https://github.com/RyanSoley"><img src="https://avatars.githubusercontent.com/u/53409969?v=4" width="100px;" alt=""/><br /><sub><b>Ryan Soley</b></sub></a><br /></td>
-    <td align="center"><a href="https://github.com/dianelee217"><img src="https://avatars.githubusercontent.com/u/67274829?v=4" width="100px;" alt=""/><br /><sub><b>Diane Lee</b></sub></a><br /></td>
+    <td align="center"><a href="https://github.com/joe-wolfe21"><img src="https://avatars.githubusercontent.com/u/10947704?v=4"
+    width="100px;" alt=""/><br /><sub><b>Joe Wolfe</b></sub></a><br /></td>
+    <td align="center"><a href="https://github.com/RyanSoley"><img src="https://avatars.githubusercontent.com/u/53409969?v=4"
+    width="100px;" alt=""/><br /><sub><b>Ryan Soley</b></sub></a><br /></td>
+    <td align="center"><a href="https://github.com/dianelee217"><img src="https://avatars.githubusercontent.com/u/67274829?v=4"
+    width="100px;" alt=""/><br /><sub><b>Diane Lee</b></sub></a><br /></td>
   </tr>
 </table>

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
+import os
+
 from setuptools import find_packages, setup
+
+pwd = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(pwd, "README.md"), encoding="utf-8") as readme:
+    long_description = readme.read()
 
 install_requires = [
     "click>=7.1",
@@ -25,8 +31,10 @@ setup(
     name="rubicon-ml",
     version="0.1.1",
     author="Joe Wolfe, Ryan Soley, Diane Lee, Mike McCarty, CapitalOne",
-    license='Apache License, Version 2.0',
+    license="Apache License, Version 2.0",
     description="an ML library for model development and governance",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     packages=find_packages(),
     include_package_data=True,
     url="https://github.com/capitalone/rubicon",
@@ -44,22 +52,18 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 4 - Beta',
-
+        "Development Status :: 4 - Beta",
         # Indicate who your project is intended for
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-
-        'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: Software Development :: Build Tools',
-        'Topic :: Software Development :: Documentation',
-
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Software Development :: Build Tools",
+        "Topic :: Software Development :: Documentation",
         # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: Apache Software License',
-
+        "License :: OSI Approved :: Apache Software License",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 3 or both.
-        'Programming Language :: Python :: 3',
+        "Programming Language :: Python :: 3",
     ],
 )


### PR DESCRIPTION
## What
  * adds the readme as a long description to the setup script so the "Project description" field on PyPi gets populated on the next release
  * uses the logo in the README - keep or naw?
    * eventually we should be able to specify a light vs dark logo ([discussion](https://github.community/t/support-theme-context-for-images-in-light-vs-dark-mode/147981))

## How to Test
  * take a look at [this branch's README](https://github.com/capitalone/rubicon/blob/pypi-long-desc/README.md)
  * make sure you can build the package
