### PR TITLE
auto versioning using git tags

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ Now `pre-commit` will run automatically on git commit and will ensure consistent
 code format throughout the project. You can format without committing via
 `pre-commit run` or skip these checks with `git commit --no-verify`.
 
+## Releasing
+
+Releasing a new version of `rubicon` to PyPi is as simple as drafting a new
+release on GitHub:
+  * from this repo's [releases](https://github.com/capitalone/rubicon/releases)
+    page, select **Draft a new release**
+  * add the new version to the **Tag version** field in **x.x.x** format 
+    (`0.1.0`, `1.2.3`, etc.) and validate that `main` is the target branch
+  * make the title of the release **vx.x.x** (`v0.1.0`, `v1.2.3`, etc.)
+  * link PRs added since the last release under the appropriate header -
+    **changelog** or **bugfixes** - in the description
+  * let our [**Publish** action](.github/workflows/publish-package.yml) handle
+    the rest!
+
+The **Publish** action builds `rubicon` and uploads it to PyPi.
+During setup, [version.py](version.py) is responsible for getting the new
+version from the latest `git` tag and bundling an updated version of
+[rubicon/_version.py](rubicon/_version.py) with the released artifact.
+
 ## Contributors
 
 <table>

--- a/rubicon/__init__.py
+++ b/rubicon/__init__.py
@@ -1,4 +1,4 @@
-from rubicon._version import get_version
+from rubicon._version import _get_version
 from rubicon.client import (
     Artifact,
     Dataframe,
@@ -10,8 +10,8 @@ from rubicon.client import (
     Rubicon,
 )
 
-__version__ = get_version()
-del get_version
+__version__ = _get_version()
+del _get_version
 
 __all__ = [
     "Artifact",

--- a/rubicon/__init__.py
+++ b/rubicon/__init__.py
@@ -1,3 +1,4 @@
+from rubicon._version import get_version
 from rubicon.client import (
     Artifact,
     Dataframe,
@@ -9,7 +10,8 @@ from rubicon.client import (
     Rubicon,
 )
 
-__version__ = "0.1.2"
+__version__ = get_version()
+del get_version
 
 __all__ = [
     "Artifact",

--- a/rubicon/_version.py
+++ b/rubicon/_version.py
@@ -1,0 +1,8 @@
+import subprocess
+
+
+def get_version():
+    get_latest_git_tag_command = ["git", "describe", "--tags", "--abbrev=0"]
+    version = subprocess.check_output(get_latest_git_tag_command, encoding="utf-8").strip()
+
+    return version

--- a/rubicon/_version.py
+++ b/rubicon/_version.py
@@ -1,7 +1,21 @@
 import subprocess
 
 
-def get_version():
+def _get_version():
+    """Gets the latest version of ``rubicon`` by inspecting the repository's
+    ``git`` tags.
+
+    Note
+    ----
+    This file will be overwritten when ``rubicon`` is packaged using ``setup.py``
+    such that ``_get_version`` returns the latest version of ``rubicon`` without
+    using ``git``.
+
+    Returns
+    -------
+    str
+        The latest version of ``rubicon``.
+    """
     get_latest_git_tag_command = ["git", "describe", "--tags", "--abbrev=0"]
     version = subprocess.check_output(get_latest_git_tag_command, encoding="utf-8").strip()
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
 
 setup(
     name="rubicon-ml",
-    version=get_version(),
+    version=get_version(write_version_file=True),
     author="Joe Wolfe, Ryan Soley, Diane Lee, Mike McCarty, CapitalOne",
     license="Apache License, Version 2.0",
     description="an ML library for model development and governance",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import os
 
 from setuptools import find_packages, setup
 
+from version import get_version
+
 pwd = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(pwd, "README.md"), encoding="utf-8") as readme:
     long_description = readme.read()
@@ -29,7 +31,7 @@ extras_require = {
 
 setup(
     name="rubicon-ml",
-    version="0.1.2",
+    version=get_version(),
     author="Joe Wolfe, Ryan Soley, Diane Lee, Mike McCarty, CapitalOne",
     license="Apache License, Version 2.0",
     description="an ML library for model development and governance",

--- a/version.py
+++ b/version.py
@@ -3,6 +3,6 @@ import subprocess
 
 def get_version():
     get_latest_git_tag_command = ["git", "describe", "--tags", "--abbrev=0"]
-    completed_subprocess = subprocess.run(get_latest_git_tag_command)
+    version = subprocess.check_output(get_latest_git_tag_command, encoding="utf-8").strip()
 
-    return completed_subprocess.stdout
+    return version

--- a/version.py
+++ b/version.py
@@ -1,0 +1,8 @@
+import subprocess
+
+
+def get_version():
+    get_latest_git_tag_command = ["git", "describe", "--tags", "--abbrev=0"]
+    completed_subprocess = subprocess.run(get_latest_git_tag_command)
+
+    return completed_subprocess.stdout

--- a/version.py
+++ b/version.py
@@ -9,7 +9,7 @@ def _write_version_file(version):
     version_file = f"def get_version():\n    return '{version}'\n"
 
     with open(version_file_path, "w") as f:
-        f.write(version_file, encoding="utf-8")
+        f.write(version_file)
 
 
 def get_version(write_version_file=False):

--- a/version.py
+++ b/version.py
@@ -1,8 +1,22 @@
+import os
 import subprocess
 
 
-def get_version():
+def _write_version_file(version):
+    root_dir = os.path.dirname(os.path.abspath(__file__))
+    version_file_path = os.path.join(root_dir, "rubicon", "_version.py")
+
+    version_file = f"def get_version():\n    return '{version}'\n"
+
+    with open(version_file_path, "w") as f:
+        f.write(version_file, encoding="utf-8")
+
+
+def get_version(write_version_file=False):
     get_latest_git_tag_command = ["git", "describe", "--tags", "--abbrev=0"]
     version = subprocess.check_output(get_latest_git_tag_command, encoding="utf-8").strip()
+
+    if write_version_file:
+        _write_version_file(version)
 
     return version

--- a/version.py
+++ b/version.py
@@ -3,16 +3,47 @@ import subprocess
 
 
 def _write_version_file(version):
+    """Overwrites the file at 'rubicon/_version.py' to contain the following
+    function where <VERSION> is the latest version of ``rubicon``:
+
+    def _get_version():
+        return '<VERSION>'
+
+    Parameters
+    ----------
+    version : str
+        The latest version of ``rubicon`` to be inserted into the generated
+        file.
+    """
     root_dir = os.path.dirname(os.path.abspath(__file__))
     version_file_path = os.path.join(root_dir, "rubicon", "_version.py")
 
-    version_file = f"def get_version():\n    return '{version}'\n"
+    version_file = f"def _get_version():\n    return '{version}'\n"
 
     with open(version_file_path, "w") as f:
         f.write(version_file)
 
 
 def get_version(write_version_file=False):
+    """Gets the latest version of ``rubicon`` by inspecting the repository's
+    ``git`` tags.
+
+    Parameters
+    ----------
+    write_version_file : bool
+        If true, rewrite the file at 'rubicon/_version.py' with the latest
+        version. Defaults to false.
+
+    Note
+    ----
+    Must be run within a clone of the ``rubicon`` repository with the
+    latest tags.
+
+    Returns
+    -------
+    str
+        The latest version of ``rubicon``.
+    """
     get_latest_git_tag_command = ["git", "describe", "--tags", "--abbrev=0"]
     version = subprocess.check_output(get_latest_git_tag_command, encoding="utf-8").strip()
 

--- a/version.py
+++ b/version.py
@@ -18,7 +18,7 @@ def _write_version_file(version):
     root_dir = os.path.dirname(os.path.abspath(__file__))
     version_file_path = os.path.join(root_dir, "rubicon", "_version.py")
 
-    version_file = f"def _get_version():\n    return '{version}'\n"
+    version_file = f'def _get_version():\n    return "{version}"\n'
 
     with open(version_file_path, "w") as f:
         f.write(version_file)


### PR DESCRIPTION
## What
  * in `version.py` and `rubicon/_version.py`, use `git` to get the version from the latest tag
    * this needs to be run from the repo with tags cloned too, which means it'll only work for devs who've installed from source (or the CI with the `fetch_depth` maxed out for now, in our case)
  * to deal with that, `setup.py` calls `version.py`'s `_write_version_file` function when the package is bundled
    * this replaces `rubicon/_version.py` with a function that returns a hardcoded string (fetched from the `git` tags in the build environment)
    * this change won't ever need to be committed to the repo, because the current `git` solution will always work for anyone installed from source

## How to Test
  * from the repo's root, run `pip install -e .`, launch a python interpreter, and `import rubicon`
    * `rubicon.__version__` should return the latest version
    * navigate out of the repo and try the same thing - `get_version` will fail since theres no git repo
  * build `rubicon` - `python setup.py sdist bdist_wheel` - and install the wheel file
    * now `rubicon.__version__` should return the latest version from a python interpreter started anywhere