### PR TITLE
add conda install instructions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,8 @@
 name: Publish docs
 
 on:
+  workflow_dispatch:
+    branch: main
   release:
     types: [created]
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,10 +4,9 @@
 name: Publish docs
 
 on:
-  workflow_dispatch:
-    branch: main
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rubicon
 
-[![PyPi Version](https://img.shields.io/pypi/v/rubicon_ml.svg)](https://pypi.org/project/rubicon-ml/)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rubicon-ml.svg)](https://anaconda.org/conda-forge/rubicon-ml)
+[![PyPi Version](https://img.shields.io/pypi/v/rubicon_ml.svg)](https://pypi.org/project/rubicon-ml/)
 [![Test Package](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml)
 [![Publish Package](https://github.com/capitalone/rubicon/actions/workflows/publish-package.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/publish-package.yml)
 [![Publish Docs](https://github.com/capitalone/rubicon/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/publish-docs.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rubicon
 
 [![PyPi Version](https://img.shields.io/pypi/v/rubicon_ml.svg)](https://pypi.org/project/rubicon-ml/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/rubicon-ml.svg)](https://anaconda.org/conda-forge/rubicon-ml)
 [![Test Package](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/test-package.yml)
 [![Publish Package](https://github.com/capitalone/rubicon/actions/workflows/publish-package.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/publish-package.yml)
 [![Publish Docs](https://github.com/capitalone/rubicon/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/capitalone/rubicon/actions/workflows/publish-docs.yml)
@@ -76,6 +77,15 @@ you have suggestions or find a bug, [please open an
 issue](https://github.com/capitalone/rubicon/issues/new/choose).
 
 ## Install
+
+`rubicon` is available on Conda Forge via `conda` and PyPi via `pip`.
+
+```
+conda config --add channels conda-forge
+conda install rubicon-ml
+```
+
+or
 
 ```
 pip install rubicon-ml

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,24 +1,46 @@
 .. _install:
 
 Install
-=======
+*******
 
-``rubicon`` is available to install via ``pip``:
+``rubicon`` is available to install via ``conda`` and ``pip``. When using ``conda``,
+make sure to set the channel to ``conda-forge``. You should only need to do this once:
+
+.. code-block:: console
+
+    conda config --add channels conda-forge
+
+then...
+
+.. code-block:: console
+
+    conda install rubicon-ml
+
+Alternatively:
 
 .. code-block:: console
 
     pip install rubicon-ml
 
-**Extras**
+Extras
+======
 
-``rubicon`` has a few optional extras:
+``rubicon`` has a few optional extras. Each are available via both ``conda`` and ``pip``.
 
 The ``ui`` extra installs the requirements necessary for using ``rubicon``'s visualization tools.
 For a preview, take a look at the **dashboard** section of the :ref:`quick look<quick-look>`.
 
 .. code-block:: console
 
+    conda install rubicon-ml[ui]
+
+or
+
+.. code-block:: console
+
     pip install rubicon-ml[ui]
+
+|
 
 The ``prefect`` extra installs the requirements necessary for using the `Prefect <https://prefect.io>`_ 
 tasks in the ``rubicon.workflow`` module. Take a look at the **Prefect integration** :ref:`example<examples>` 
@@ -26,9 +48,23 @@ to see ``rubicon`` integrated into a simple Prefect flow.
 
 .. code-block:: console
 
+    conda install rubicon-ml[prefect]
+
+or
+
+.. code-block:: console
+
     pip install rubicon-ml[prefect]
 
+|
+
 To install all extra modules, use the ``all`` extra.
+
+.. code-block:: console
+
+    conda install rubicon-ml[all]
+
+or
 
 .. code-block:: console
 


### PR DESCRIPTION
## What
  * adds the install instructions back in now that `rubicon` is available on `conda`
