### PR TITLE
Speed up install

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: rubicon-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.8.0
+  - python=3.8
   - pip
 
   - click>=7.1

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,4 +1,4 @@
-name: rubicon-dev
+name: rubicon-dev-test-2
 channels:
   - conda-forge
 dependencies:
@@ -8,7 +8,7 @@ dependencies:
   - click>=7.1
   - dask>=2.12.0
   - pandas>=1.0
-  - fsspec=0.8.3
+  - fsspec>=0.8.3
   - intake>=0.5.2
   - pyarrow>=0.18.0
   - pyyaml>=5.4.0

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,8 +10,8 @@ dependencies:
   - pandas>=1.0
   - fsspec=0.8.3
   - intake>=0.5.2
-  - pyarrow>=0.16.0,<0.18.0
-  - pyyaml>=5.3.0,<5.4.0
+  - pyarrow>=0.18.0
+  - pyyaml>=5.4.0
 
   # required for S3 backend
   - s3fs>=0.5.1

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,4 +1,4 @@
-name: rubicon-dev-test-2
+name: rubicon-dev
 channels:
   - conda-forge
 dependencies:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: rubicon-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.7.6
+  - python=3.8.0
   - pip
 
   - click>=7.1

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ install_requires = [
     "dask[dataframe]>=2.12.0",
     "fsspec>=0.8.3",
     "intake>=0.5.2",
-    "pyarrow>=0.16.0,<0.18.0",
-    "pyyaml>=3.12.0,<5.4.0",
+    "pyarrow>=0.18.0",
+    "pyyaml>=5.4.0",
     "s3fs>=0.5.1",
 ]
 


### PR DESCRIPTION
closes: #30 

---

## What

Unpins the upper bounds on a few dependencies based on the feedback in #30. `s3fs` and `pyarrow` are required as part of the install, unless we want to update to make them optional installs based on how rubicon is used (i.e. s3? -> s3fs). Although for now I think it's fine to leave as is

The install time dropped a couple mins for me
