### PR TITLE
remove `fsspec` bug workarounds

### DIFF
--- a/rubicon/repository/memory.py
+++ b/rubicon/repository/memory.py
@@ -1,4 +1,3 @@
-import os
 import pickle
 
 import fsspec
@@ -30,38 +29,6 @@ class MemoryRepository(LocalRepository):
         self.root_dir = root_dir.rstrip("/") if root_dir is not None else "/root"
 
         self.filesystem.mkdir(self.root_dir)
-
-    def _add_dirnames_to_pseudo_dirs(self, path):
-        """Adds each persisted in-memory file's directory to
-        `fsspec`'s `pseudo_dirs`.
-
-        This is a workaround to a bug in `fsspec` where the
-        memory filesystem does not properly populate the
-        `pseudo_dirs` list.
-        """
-        pseudo_dirs = set(self.filesystem.pseudo_dirs)
-
-        while path != "" and path != "/":
-            path = os.path.dirname(path)
-            pseudo_dirs.add(path)
-
-        self.filesystem.pseudo_dirs = list(pseudo_dirs)
-
-    def _persist_bytes(self, bytes_data, path):
-        """Persists the Rubicon object `domain` to the
-        in-memory path defined by `path`.
-        """
-        super()._persist_bytes(bytes_data, path)
-
-        self._add_dirnames_to_pseudo_dirs(path)
-
-    def _persist_domain(self, domain, path):
-        """Persists the Rubicon object `domain` to the
-        in-memory path defined by `path`.
-        """
-        super()._persist_domain(domain, path)
-
-        self._add_dirnames_to_pseudo_dirs(path)
 
     def _persist_dataframe(self, df, path):
         """Persists the `dask` dataframe `df` to the in-memory

--- a/tests/unit/repository/test_memory_repo.py
+++ b/tests/unit/repository/test_memory_repo.py
@@ -1,4 +1,3 @@
-import os
 import pickle
 
 import fsspec
@@ -13,17 +12,6 @@ def test_initialization():
     assert memory_repo.PROTOCOL == "memory"
     assert memory_repo.root_dir == "/root"
     assert type(memory_repo.filesystem) == fsspec.implementations.memory.MemoryFileSystem
-
-
-def test_add_dirnames_to_pseudo_dirs():
-    path = "/memory/root/data.json"
-
-    memory_repo = MemoryRepository()
-    memory_repo._add_dirnames_to_pseudo_dirs(path)
-
-    while path != "" and path != "/":
-        path = os.path.dirname(path)
-        assert path in memory_repo.filesystem.pseudo_dirs
 
 
 def test_persist_dataframe():


### PR DESCRIPTION
closes: #38 

---

## What
  * removes the workaround for the `fsspec` memory fs bug and the related tests

## How to Test
  * `python -m pytest`
  * run through a notebook or two using the memory fs
