### PR TITLE
Docs Release

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,10 +3,14 @@
 # For more details: https://github.com/marketplace/actions/deploy-to-github-pages
 name: Publish docs
 
+# on:
+#   release:
+#     types: [created]
+#   workflow_dispatch:
+
 on:
-  release:
-    types: [created]
-  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build-and-deploy:
@@ -27,13 +31,13 @@ jobs:
     - name: Install dependencies
       run: |
         conda env update --file docs/docs-environment.yml --name base
-    - name: Build
-      run: |
-        cd docs
-        bash build-docs.sh
-      shell: bash
-    - name: Publish
-      uses: JamesIves/github-pages-deploy-action@4.0.0
-      with:
-        branch: gh-pages
-        folder: docs/build/html
+    # - name: Build
+    #   run: |
+    #     cd docs
+    #     bash build-docs.sh
+    #   shell: bash
+    # - name: Publish
+    #   uses: JamesIves/github-pages-deploy-action@4.0.0
+    #   with:
+    #     branch: gh-pages
+    #     folder: docs/build/html

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,14 +3,10 @@
 # For more details: https://github.com/marketplace/actions/deploy-to-github-pages
 name: Publish docs
 
-# on:
-#   release:
-#     types: [created]
-#   workflow_dispatch:
-
 on:
-  pull_request:
-    branches: [ main ]
+  release:
+    types: [created]
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:
@@ -31,13 +27,13 @@ jobs:
     - name: Install dependencies
       run: |
         conda env update --file docs/docs-environment.yml --name base
-    # - name: Build
-    #   run: |
-    #     cd docs
-    #     bash build-docs.sh
-    #   shell: bash
-    # - name: Publish
-    #   uses: JamesIves/github-pages-deploy-action@4.0.0
-    #   with:
-    #     branch: gh-pages
-    #     folder: docs/build/html
+    - name: Build
+      run: |
+        cd docs
+        bash build-docs.sh
+      shell: bash
+    - name: Publish
+      uses: JamesIves/github-pages-deploy-action@4.0.0
+      with:
+        branch: gh-pages
+        folder: docs/build/html

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - jupyter_client
   - scikit-learn
   - hvplot
+  - pyyaml>=5.4.0
 
   - pip:
     - -e ../[all]


### PR DESCRIPTION
## What

The publish docs action was failing with error:

> ERROR: Cannot uninstall ‘PyYAML’. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.

Setting the version of pyyaml within conda env to match the version installed by pip in `setup.py` seemed to resolve the issue

## How to test

I modified the doc workflow to run on this PR and it installed properly [here](https://github.com/capitalone/rubicon/pull/41/checks?check_run_id=2087475061)