### PR TITLE
Use conda incubator action for environment setup

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -26,7 +26,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        miniforge-version: latest
+        miniconda-version: latest
         channels: conda-forge
         channel-priority: true  
         activate-environment: rubicon-dev

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,17 +21,14 @@ jobs:
         # fetch all tags so `versioneer` can properly determine current version
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env update --file ci/environment.yml --name base
-        pip install setuptools wheel
+        mamba-version: "*"
+        channels: conda-forge, defaults
+        channel-priority: true  
+        activate-environment: rubicon-dev
+        environment-file: ci/environment.yml
     - name: Check formatting with black
       run: |
         black --check .

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -14,7 +14,9 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -24,8 +26,8 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-        channels: conda-forge, defaults
+        miniforge-version: latest
+        channels: conda-forge
         channel-priority: true  
         activate-environment: rubicon-dev
         environment-file: ci/environment.yml

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     defaults:
       run:
         shell: bash -l {0}

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,6 @@ name: rubicon-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
   - pip
 
   - click>=7.1
@@ -31,10 +30,11 @@ dependencies:
   - isort
   - pytest
   - pytest-cov
+  - percy>=2.0.2
 
   # required for versioning
   - versioneer
 
-  - pip:
-    # required for UI testing (not available on conda)
-    - percy>=2.0.2
+  # packaging
+  - wheel
+  - setuptools

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     url="https://github.com/capitalone/rubicon",
+    python_requires=">=3.7",
     install_requires=install_requires,
     extras_require=extras_require,
     entry_points={


### PR DESCRIPTION
Unpin Python in environment file to make sure Python version is not
always 3.8

closes: #42

---

## What
  * Uses the `conda-incubator` action for more flexible miniconda setup
  * Unset strict python version in environment file so the version matrix checks all the versions 
  * Add percy to conda instead of using pip

## How to Test
  * I think if the CI passes it works?
