### PR TITLE
47 support pandas df

### DIFF
--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -388,19 +388,12 @@ class BaseRepository:
 
         return f"{dataframe_metadata_root}/{dataframe_id}/data"
 
-    def _convert_to_dask_dataframe(self, df):
-        """Converts `df` to a Dask dataframe if it is not already one."""
-        if not isinstance(df, dd.DataFrame):
-            return dd.from_pandas(df, npartitions=1)
-
-        return df
-
     def _persist_dataframe(self, df, path):
-        """Persists the `dask` dataframe `df` to the configured filesystem."""
+        """Persists the dataframe `df` to the configured filesystem."""
         df.to_parquet(path, engine="pyarrow")
 
     def _read_dataframe(self, path):
-        """Reads the `dask` dataframe `df` from the configured filesystem."""
+        """Reads the dataframe `df` from the configured filesystem."""
         return dd.read_parquet(path, engine="pyarrow")
 
     def create_dataframe(self, dataframe, data, project_name, experiment_id=None):
@@ -419,8 +412,6 @@ class BaseRepository:
             The ID of the experiment this dataframe belongs to.
             Dataframes do not need to belong to an experiment.
         """
-        data = self._convert_to_dask_dataframe(data)
-
         dataframe_metadata_path = self._get_dataframe_metadata_path(
             project_name, experiment_id, dataframe.id
         )

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -64,10 +64,10 @@ def _create_dask_dataframe(repository, project=None):
         project = _create_project(repository)
     
     df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
-    dd.from_pandas(df, npartitions=1)
+    ddf = dd.from_pandas(df, npartitions=1)
 
     dataframe = domain.Dataframe(parent_id=project.id)
-    repository.create_dataframe(dataframe, df, project.name)
+    repository.create_dataframe(dataframe, ddf, project.name)
 
     return dataframe
 
@@ -483,7 +483,7 @@ def test_get_dask_dataframe(memory_repository):
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
 
     data = repository.get_dataframe_data(project.name, written_dataframe.id)
-    assert not data.empty
+    assert not data.compute().empty
 
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -50,7 +50,7 @@ def _create_pandas_dataframe(repository, project=None, dataframe_data=None, mult
         project = _create_project(repository)
 
     if dataframe_data is None:
-        dataframe_data = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+        dataframe_data = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
         if multi_index:
             dataframe_data = dataframe_data.set_index(['b', 'a']) # Set multiindex
 
@@ -63,7 +63,7 @@ def _create_dask_dataframe(repository, project=None):
     if project is None:
         project = _create_project(repository)
     
-    df = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+    df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
     dd.from_pandas(df, npartitions=1)
 
     dataframe = domain.Dataframe(parent_id=project.id)
@@ -456,15 +456,21 @@ def test_get_pandas_dataframe(memory_repository):
     written_dataframe = _create_pandas_dataframe(repository, project=project)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
 
+    data = repository.get_dataframe_data(project.name, written_dataframe.id)
+    assert not data.empty
+
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id
 
 
-def test_get_multi_index_dataframe(memory_repository):
+def test_get_pandas_multi_index_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
     written_dataframe = _create_pandas_dataframe(repository, project=project, multi_index=True)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    data = repository.get_dataframe_data(project.name, written_dataframe.id)
+    assert not data.empty
 
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id
@@ -475,6 +481,9 @@ def test_get_dask_dataframe(memory_repository):
     project = _create_project(repository)
     written_dataframe = _create_dask_dataframe(repository, project=project)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    data = repository.get_dataframe_data(project.name, written_dataframe.id)
+    assert not data.empty
 
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -45,18 +45,31 @@ def _create_artifact(repository, project=None, artifact_data=None):
     return artifact
 
 
-def _create_dataframe(repository, project=None, dataframe_data=None):
+def _create_pandas_dataframe(repository, project=None, dataframe_data=None, multi_index=False):
     if project is None:
         project = _create_project(repository)
 
     if dataframe_data is None:
         dataframe_data = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+        if multi_index:
+            dataframe_data = dataframe_data.set_index(['b', 'a']) # Set multiindex
 
     dataframe = domain.Dataframe(parent_id=project.id)
     repository.create_dataframe(dataframe, dataframe_data, project.name)
 
     return dataframe
 
+def _create_dask_dataframe(repository, project=None):
+    if project is None:
+        project = _create_project(repository)
+    
+    df = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+    dd.from_pandas(df, npartitions=1)
+
+    dataframe = domain.Dataframe(parent_id=project.id)
+    repository.create_dataframe(dataframe, df, project.name)
+
+    return dataframe
 
 def _create_feature(repository, experiment=None):
     if experiment is None:
@@ -357,7 +370,6 @@ def test_persist_dataframe(mock_to_parquet, memory_repository):
 
     mock_to_parquet.assert_called_once_with(path, engine="pyarrow")
 
-
 @patch("dask.dataframe.read_parquet")
 def test_read_dataframe(mock_read_parquet, memory_repository):
     repository = memory_repository
@@ -389,10 +401,10 @@ def test_get_dataframe_with_experiment_parent_root(memory_repository):
     )
 
 
-def test_create_dataframe(memory_repository):
+def test_create_pandas_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project)
 
     dataframe_root = f"{repository.root_dir}/{slugify(project.name)}/dataframes/{dataframe.id}"
     dataframe_metadata_path = f"{dataframe_root}/metadata.json"
@@ -406,10 +418,62 @@ def test_create_dataframe(memory_repository):
     assert dataframe.id == dataframe_json["id"]
 
 
-def test_get_dataframe(memory_repository):
+def test_create_pandas_multi_index_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    written_dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project, multi_index=True)
+
+    dataframe_root = f"{repository.root_dir}/{slugify(project.name)}/dataframes/{dataframe.id}"
+    dataframe_metadata_path = f"{dataframe_root}/metadata.json"
+    dataframe_data_path = f"{dataframe_root}/data"
+
+    open_file = repository.filesystem.open(dataframe_metadata_path)
+    with open_file as f:
+        dataframe_json = json.load(f)
+
+    assert repository.filesystem.exists(dataframe_data_path)
+    assert dataframe.id == dataframe_json["id"]
+
+def test_create_dask_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    dataframe = _create_dask_dataframe(repository, project=project)
+
+    dataframe_root = f"{repository.root_dir}/{slugify(project.name)}/dataframes/{dataframe.id}"
+    dataframe_metadata_path = f"{dataframe_root}/metadata.json"
+    dataframe_data_path = f"{dataframe_root}/data"
+
+    open_file = repository.filesystem.open(dataframe_metadata_path)
+    with open_file as f:
+        dataframe_json = json.load(f)
+
+    assert repository.filesystem.exists(dataframe_data_path)
+    assert dataframe.id == dataframe_json["id"]
+
+def test_get_pandas_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    written_dataframe = _create_pandas_dataframe(repository, project=project)
+    dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    assert dataframe.id == written_dataframe.id
+    assert dataframe.parent_id == written_dataframe.parent_id
+
+
+def test_get_multi_index_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    written_dataframe = _create_pandas_dataframe(repository, project=project, multi_index=True)
+    dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    assert dataframe.id == written_dataframe.id
+    assert dataframe.parent_id == written_dataframe.parent_id
+
+
+def test_get_dask_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    written_dataframe = _create_dask_dataframe(repository, project=project)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
 
     assert dataframe.id == written_dataframe.id
@@ -430,7 +494,7 @@ def test_get_dataframe_throws_error_if_not_found(memory_repository):
 def test_get_dataframes(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    written_dataframes = [_create_dataframe(repository, project=project) for _ in range(0, 3)]
+    written_dataframes = [_create_pandas_dataframe(repository, project=project) for _ in range(0, 3)]
     dataframes = repository.get_dataframes_metadata(project.name)
 
     dataframe_ids = [d.id for d in written_dataframes]
@@ -453,7 +517,7 @@ def test_get_dataframe_data(memory_repository):
     dataframe_data = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
     dataframe_data = dd.from_pandas(dataframe_data, npartitions=1)
 
-    dataframe = _create_dataframe(repository, project=project, dataframe_data=dataframe_data)
+    dataframe = _create_pandas_dataframe(repository, project=project, dataframe_data=dataframe_data)
     data = repository.get_dataframe_data(project.name, dataframe.id)
 
     assert dataframe_data.compute().equals(data.compute())
@@ -473,7 +537,7 @@ def test_get_dataframe_data_throws_error_if_not_found(memory_repository):
 def test_delete_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project)
 
     repository.delete_dataframe(project.name, dataframe.id)
 
@@ -731,7 +795,7 @@ def test_get_experiment_tags_root(memory_repository):
 def test_get_dataframe_tags_with_project_parent_root(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project)
     dataframe_tags_root = repository._get_tag_metadata_root(project.name, dataframe_id=dataframe.id)
 
     assert (


### PR DESCRIPTION
closes: #47 

---

## What

Adds support for logging either a `pandas` or `dask` df. It's only added to the sync methods for now and if all looks good, will update the corresponding async methods too.

## How to Test

I've added tests for pandas, multiindex pandas, and dask dfs, check if any edge cases are missed. Also left a detailed example on the issue [here](https://github.com/capitalone/rubicon/issues/47#issuecomment-802900614)
