### PR TITLE
Support logging either pandas or dask dataframes

### DIFF
--- a/rubicon/client/dataframe.py
+++ b/rubicon/client/dataframe.py
@@ -36,7 +36,10 @@ class Dataframe(Base, TagMixin):
         project_name, experiment_id = self.parent._get_parent_identifiers()
 
         self._data = self.repository.get_dataframe_data(
-            project_name, self.id, experiment_id=experiment_id, kind=kind,
+            project_name,
+            self.id,
+            experiment_id=experiment_id,
+            kind=kind,
         )
 
         return self._data
@@ -88,8 +91,7 @@ class Dataframe(Base, TagMixin):
 
     @property
     def data(self):
-        """Get the dataframe's data as it was logged.
-        """
+        """Get the dataframe's data as it was logged."""
         if self._data is None:
             self.get_data()
 

--- a/rubicon/client/dataframe.py
+++ b/rubicon/client/dataframe.py
@@ -31,7 +31,7 @@ class Dataframe(Base, TagMixin):
 
     def get_data(self, kind="pandas"):
         """Loads the data associated with this Dataframe
-        into a pandas or dask dataframe.
+        into a `pandas` or `dask` dataframe.
         """
         project_name, experiment_id = self.parent._get_parent_identifiers()
 

--- a/rubicon/client/dataframe.py
+++ b/rubicon/client/dataframe.py
@@ -29,14 +29,14 @@ class Dataframe(Base, TagMixin):
         self._data = None
         self._parent = parent
 
-    def _get_data(self):
+    def get_data(self, kind="pandas"):
         """Loads the data associated with this Dataframe
-        into a `dask.dataframe.DataFrame`.
+        into a pandas or dask dataframe.
         """
         project_name, experiment_id = self.parent._get_parent_identifiers()
 
         self._data = self.repository.get_dataframe_data(
-            project_name, self.id, experiment_id=experiment_id
+            project_name, self.id, experiment_id=experiment_id, kind=kind,
         )
 
     def plot(self, **kwargs):
@@ -90,7 +90,7 @@ class Dataframe(Base, TagMixin):
         `dask.dataframe.DataFrame`.
         """
         if self._data is None:
-            self._get_data()
+            self.get_data()
 
         return self._data
 

--- a/rubicon/client/dataframe.py
+++ b/rubicon/client/dataframe.py
@@ -1,3 +1,5 @@
+import warnings
+
 from rubicon.client import Base, TagMixin
 from rubicon.exceptions import RubiconException
 
@@ -44,7 +46,7 @@ class Dataframe(Base, TagMixin):
 
         return self._data
 
-    def plot(self, **kwargs):
+    def plot(self, kind="pandas", **kwargs):
         """Render the dataframe using `hvplot`.
 
         Parameters
@@ -65,14 +67,14 @@ class Dataframe(Base, TagMixin):
         >>> dataframe.plot(kind='line', x='Year', y='Number of Subscriptions')
         """
         try:
-            # data is a dask dataframe
             import hvplot.dask  # noqa F401
+            import hvplot.pandas  # noqa F401
         except ImportError:
             raise RubiconException(
                 "`hvplot` is required for plotting. Install with `pip install hvplot`."
             )
 
-        return self.data.hvplot(**kwargs)
+        return self.get_data(kind=kind).hvplot(**kwargs)
 
     @property
     def id(self):
@@ -92,6 +94,10 @@ class Dataframe(Base, TagMixin):
     @property
     def data(self):
         """Get the dataframe's data as it was logged."""
+        warnings.warn(
+            "`data` is deprecated, use `get_data()` instead",
+            DeprecationWarning,
+        )
         if self._data is None:
             self.get_data()
 

--- a/rubicon/client/dataframe.py
+++ b/rubicon/client/dataframe.py
@@ -67,8 +67,10 @@ class Dataframe(Base, TagMixin):
         >>> dataframe.plot(kind='line', x='Year', y='Number of Subscriptions')
         """
         try:
-            import hvplot.dask  # noqa F401
-            import hvplot.pandas  # noqa F401
+            if kind == "pandas":
+                import hvplot.pandas  # noqa F401
+            else:
+                import hvplot.dask  # noqa F401
         except ImportError:
             raise RubiconException(
                 "`hvplot` is required for plotting. Install with `pip install hvplot`."

--- a/rubicon/client/dataframe.py
+++ b/rubicon/client/dataframe.py
@@ -39,6 +39,8 @@ class Dataframe(Base, TagMixin):
             project_name, self.id, experiment_id=experiment_id, kind=kind,
         )
 
+        return self._data
+
     def plot(self, **kwargs):
         """Render the dataframe using `hvplot`.
 
@@ -86,8 +88,7 @@ class Dataframe(Base, TagMixin):
 
     @property
     def data(self):
-        """Get the dataframe's raw data loaded into a
-        `dask.dataframe.DataFrame`.
+        """Get the dataframe's data as it was logged.
         """
         if self._data is None:
             self.get_data()

--- a/rubicon/repository/asynchronous/base.py
+++ b/rubicon/repository/asynchronous/base.py
@@ -546,8 +546,6 @@ class AsynchronousBaseRepository(BaseRepository):
             The ID of the experiment this dataframe belongs to.
             Dataframes do not need to belong to an experiment.
         """
-        data = self._convert_to_dask_dataframe(data)
-
         dataframe_metadata_path = self._get_dataframe_metadata_path(
             project_name, experiment_id, dataframe.id
         )

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -388,19 +388,12 @@ class BaseRepository:
 
         return f"{dataframe_metadata_root}/{dataframe_id}/data"
 
-    def _convert_to_dask_dataframe(self, df):
-        """Converts `df` to a Dask dataframe if it is not already one."""
-        if not isinstance(df, dd.DataFrame):
-            return dd.from_pandas(df, npartitions=1)
-
-        return df
-
     def _persist_dataframe(self, df, path):
-        """Persists the `dask` dataframe `df` to the configured filesystem."""
+        """Persists the dataframe `df` to the configured filesystem."""
         df.to_parquet(path, engine="pyarrow")
 
     def _read_dataframe(self, path):
-        """Reads the `dask` dataframe `df` from the configured filesystem."""
+        """Reads the dataframe `df` from the configured filesystem."""
         return dd.read_parquet(path, engine="pyarrow")
 
     def create_dataframe(self, dataframe, data, project_name, experiment_id=None):
@@ -419,8 +412,6 @@ class BaseRepository:
             The ID of the experiment this dataframe belongs to.
             Dataframes do not need to belong to an experiment.
         """
-        data = self._convert_to_dask_dataframe(data)
-
         dataframe_metadata_path = self._get_dataframe_metadata_path(
             project_name, experiment_id, dataframe.id
         )

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -395,9 +395,9 @@ class BaseRepository:
         
         Note
         ----
-        Dask dataframes will automatically be split into chunks by dask.dataframe.to_parquet.
-        Pandas, however, will be saved as a single file with the hope that users would leverage
-        dask for large dataframes.
+        Dask dataframes will automatically be split into chunks by `dask.dataframe.to_parquet`.
+        Pandas dataframes, however, will be saved as a single file with the hope that users
+        would leverage dask for large dataframes.
         """
         if isinstance(df, pd.DataFrame):
             Path(path).mkdir(parents=True, exist_ok=True)

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -395,8 +395,8 @@ class BaseRepository:
 
         Note
         ----
-        Dask dataframes will automatically be split into chunks by `dask.dataframe.to_parquet`.
-        Pandas dataframes, however, will be saved as a single file with the hope that users
+        `dask` dataframes will automatically be split into chunks by `dask.dataframe.to_parquet`.
+        `pandas` dataframes, however, will be saved as a single file with the hope that users
         would leverage dask for large dataframes.
         """
         if isinstance(df, pd.DataFrame):

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -539,7 +539,7 @@ class BaseRepository:
         try:
             df = self._read_dataframe(dataframe_data_path, kind)
         except FileNotFoundError:
-            raise RubiconException(f"No data for dataframe with id `{dataframe_id}` found.")
+            raise RubiconException(f"No data for dataframe with id `{dataframe_id}` found. This might have happened if you forgot to set `kind='dask'` when trying to read dask dataframe.")
 
         return df
 

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -1,9 +1,9 @@
 import os
+from pathlib import Path
 
 import fsspec
 import pandas as pd
 from dask import dataframe as dd
-from pathlib import Path
 
 from rubicon import domain
 from rubicon.exceptions import RubiconException
@@ -392,7 +392,7 @@ class BaseRepository:
 
     def _persist_dataframe(self, df, path):
         """Persists the dataframe `df` to the configured filesystem.
-        
+
         Note
         ----
         Dask dataframes will automatically be split into chunks by `dask.dataframe.to_parquet`.
@@ -539,7 +539,9 @@ class BaseRepository:
         try:
             df = self._read_dataframe(dataframe_data_path, kind)
         except FileNotFoundError:
-            raise RubiconException(f"No data for dataframe with id `{dataframe_id}` found. This might have happened if you forgot to set `kind='dask'` when trying to read dask dataframe.")
+            raise RubiconException(
+                f"No data for dataframe with id `{dataframe_id}` found. This might have happened if you forgot to set `kind='dask'` when trying to read dask dataframe."
+            )
 
         return df
 

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -540,7 +540,8 @@ class BaseRepository:
             df = self._read_dataframe(dataframe_data_path, kind)
         except FileNotFoundError:
             raise RubiconException(
-                f"No data for dataframe with id `{dataframe_id}` found. This might have happened if you forgot to set `kind='dask'` when trying to read dask dataframe."
+                f"No data for dataframe with id `{dataframe_id}` found. This might have "
+                "happened if you forgot to set `kind='dask'` when trying to read a `dask` dataframe."
             )
 
         return df

--- a/rubicon/repository/memory.py
+++ b/rubicon/repository/memory.py
@@ -38,7 +38,7 @@ class MemoryRepository(LocalRepository):
             pickle.dump(df, f)
 
     def _read_dataframe(self, path, kind="pandas"):
-        """Reads the `dask` dataframe `df` from the in-memory
+        """Reads the dataframe from the in-memory
         path defined by `path`.
         """
         with self.filesystem.open(path, "rb") as f:

--- a/rubicon/repository/memory.py
+++ b/rubicon/repository/memory.py
@@ -37,7 +37,7 @@ class MemoryRepository(LocalRepository):
         with self.filesystem.open(path, "wb") as f:
             pickle.dump(df, f)
 
-    def _read_dataframe(self, path):
+    def _read_dataframe(self, path, kind="pandas"):
         """Reads the `dask` dataframe `df` from the in-memory
         path defined by `path`.
         """

--- a/tests/integration/test_concurrency.py
+++ b/tests/integration/test_concurrency.py
@@ -8,8 +8,6 @@ from rubicon.domain.utils import uuid
 
 def _log_all_to_experiment(experiment):
     ddf = dd.from_pandas(pd.DataFrame([0, 1], columns=["a"]), npartitions=1)
-    multi_index_df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
-    multi_index_df = multi_index_df.set_index(['b', 'a'])
 
     for _ in range(0, 4):
         experiment.log_metric(uuid.uuid4(), 0)
@@ -17,7 +15,6 @@ def _log_all_to_experiment(experiment):
         experiment.log_parameter(uuid.uuid4(), 1)
         experiment.log_artifact(data_bytes=b"artifact bytes", name=uuid.uuid4())
         experiment.log_dataframe(ddf)
-        experiment.log_dataframe(multi_index_df)
         experiment.add_tags([uuid.uuid4()])
 
 
@@ -56,5 +53,5 @@ def test_filesystem_concurrency(rubicon_local_filesystem_client):
     assert len(experiment.features()) == 16
     assert len(experiment.parameters()) == 16
     assert len(experiment.artifacts()) == 16
-    assert len(experiment.dataframes()) == 32
+    assert len(experiment.dataframes()) == 16
     assert len(experiment.tags) == 16

--- a/tests/integration/test_concurrency.py
+++ b/tests/integration/test_concurrency.py
@@ -56,5 +56,5 @@ def test_filesystem_concurrency(rubicon_local_filesystem_client):
     assert len(experiment.features()) == 16
     assert len(experiment.parameters()) == 16
     assert len(experiment.artifacts()) == 16
-    assert len(experiment.dataframes()) == 16
+    assert len(experiment.dataframes()) == 32
     assert len(experiment.tags) == 16

--- a/tests/integration/test_concurrency.py
+++ b/tests/integration/test_concurrency.py
@@ -1,19 +1,23 @@
 import multiprocessing
 
 import pandas as pd
+from dask import dataframe as dd
 
 from rubicon.domain.utils import uuid
 
 
 def _log_all_to_experiment(experiment):
-    df = pd.DataFrame([0, 1], columns=["a"])
+    ddf = dd.from_pandas(pd.DataFrame([0, 1], columns=["a"]), npartitions=1)
+    multi_index_df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
+    multi_index_df = multi_index_df.set_index(['b', 'a'])
 
     for _ in range(0, 4):
         experiment.log_metric(uuid.uuid4(), 0)
         experiment.log_feature(uuid.uuid4())
         experiment.log_parameter(uuid.uuid4(), 1)
         experiment.log_artifact(data_bytes=b"artifact bytes", name=uuid.uuid4())
-        experiment.log_dataframe(df)
+        experiment.log_dataframe(ddf)
+        experiment.log_dataframe(multi_index_df)
         experiment.add_tags([uuid.uuid4()])
 
 

--- a/tests/integration/test_dataframe_logging.py
+++ b/tests/integration/test_dataframe_logging.py
@@ -62,6 +62,6 @@ def test_df_read_error(rubicon_local_filesystem_client):
         read_dataframe.get_data()
 
     assert (
-        "This might have happened if you forgot to set `kind='dask'` when trying to read dask dataframe."
+        "This might have happened if you forgot to set `kind='dask'` when trying to read a `dask` dataframe."
         in str(e)
     )

--- a/tests/integration/test_dataframe_logging.py
+++ b/tests/integration/test_dataframe_logging.py
@@ -1,0 +1,58 @@
+import pytest
+import pandas as pd
+from dask import dataframe as dd
+from rubicon.exceptions import RubiconException
+
+def test_pandas_df(rubicon_local_filesystem_client):
+    rubicon = rubicon_local_filesystem_client
+    project = rubicon.create_project("Dataframe Test Project")
+    
+    multi_index_df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
+    multi_index_df = multi_index_df.set_index(['b', 'a'])
+
+    written_dataframe = project.log_dataframe(multi_index_df)
+
+    read_dataframes = project.dataframes()
+    read_dataframe = read_dataframes[0]
+
+    assert len(read_dataframes) == 1
+
+    assert read_dataframe.id == written_dataframe.id
+    assert read_dataframe.get_data().equals(multi_index_df)
+
+def test_dask_df(rubicon_local_filesystem_client):
+    rubicon = rubicon_local_filesystem_client
+    project = rubicon.create_project("Dataframe Test Project")
+    
+    ddf = dd.from_pandas(pd.DataFrame([0, 1], columns=["a"]), npartitions=1)
+
+    written_dataframe = project.log_dataframe(ddf)
+
+    read_dataframes = project.dataframes()
+    read_dataframe = read_dataframes[0]
+
+    assert len(read_dataframes) == 1
+
+    assert read_dataframe.id == written_dataframe.id
+    assert read_dataframe.get_data(kind="dask").compute().equals(ddf.compute())
+
+def test_df_read_error(rubicon_local_filesystem_client):
+    rubicon = rubicon_local_filesystem_client
+    project = rubicon.create_project("Dataframe Test Project")
+    
+    ddf = dd.from_pandas(pd.DataFrame([0, 1], columns=["a"]), npartitions=1)
+
+    written_dataframe = project.log_dataframe(ddf)
+
+    read_dataframes = project.dataframes()
+    read_dataframe = read_dataframes[0]
+
+    assert len(read_dataframes) == 1
+
+    assert read_dataframe.id == written_dataframe.id
+    
+    # simulate user forgetting to set `kind` to `dask` when reading a logged dask df
+    with pytest.raises(RubiconException) as e:
+        read_dataframe.get_data()
+
+    assert f"This might have happened if you forgot to set `kind='dask'` when trying to read dask dataframe." in str(e)

--- a/tests/integration/test_prefect_flow.py
+++ b/tests/integration/test_prefect_flow.py
@@ -92,7 +92,7 @@ def test_flow():
     dataframes = experiment.dataframes()
     assert len(dataframes) == 1
     assert dataframes[0].description == "a test df"
-    assert df.equals(dataframes[0].data.compute())
+    assert df.equals(dataframes[0].data)
 
     # artifacts
     artifacts = experiment.artifacts()

--- a/tests/integration/test_rubicon.py
+++ b/tests/integration/test_rubicon.py
@@ -94,9 +94,7 @@ def test_rubicon(rubicon, request):
     read_project_dataframes = read_project.dataframes()
     assert len(read_project_dataframes) == 1
     assert written_project_dataframe.id == read_project_dataframes[0].id
-    assert written_project_dataframe.data.equals(
-        read_project_dataframes[0].data
-    )
+    assert written_project_dataframe.data.equals(read_project_dataframes[0].data)
     assert written_project_dataframe.tags == read_project_dataframes[0].tags
 
     read_project.delete_dataframes([read_project_dataframes[0].id])

--- a/tests/integration/test_rubicon.py
+++ b/tests/integration/test_rubicon.py
@@ -100,8 +100,8 @@ def test_rubicon(rubicon, request):
     read_project_dataframes = read_project.dataframes()
     assert len(read_project_dataframes) == 1
     assert written_project_dataframe.id == read_project_dataframes[0].id
-    assert written_project_dataframe.data.compute().equals(
-        read_project_dataframes[0].data.compute()
+    assert written_project_dataframe.data.equals(
+        read_project_dataframes[0].data
     )
     assert written_project_dataframe.tags == read_project_dataframes[0].tags
 
@@ -111,8 +111,8 @@ def test_rubicon(rubicon, request):
     read_experiment_dataframes = read_experiment.dataframes()
     assert len(read_experiment_dataframes) == 1
     assert written_experiment_dataframe.id == read_experiment_dataframes[0].id
-    assert written_experiment_dataframe.data.compute().equals(
-        read_experiment_dataframes[0].data.compute()
+    assert written_experiment_dataframe.data.equals(
+        read_experiment_dataframes[0].data
     )
     assert written_experiment_dataframe.tags == read_experiment_dataframes[0].tags
 

--- a/tests/integration/test_rubicon.py
+++ b/tests/integration/test_rubicon.py
@@ -50,15 +50,9 @@ def test_rubicon(rubicon, request):
     written_project_dataframe = written_project.log_dataframe(
         df=pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
     )
-    written_experiment_dataframe = written_experiment.log_dataframe(
-        df=pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
-    )
 
     written_project_dataframe.add_tags(["x", "y"])
     written_project_dataframe.remove_tags(["x"])
-
-    written_experiment_dataframe.add_tags(["x", "y"])
-    written_experiment_dataframe.remove_tags(["x"])
 
     read_project = rubicon.get_project(name=written_project.name)
     assert written_project.id == read_project.id
@@ -107,13 +101,5 @@ def test_rubicon(rubicon, request):
 
     read_project.delete_dataframes([read_project_dataframes[0].id])
     assert len(read_project.dataframes()) == 0
-
-    read_experiment_dataframes = read_experiment.dataframes()
-    assert len(read_experiment_dataframes) == 1
-    assert written_experiment_dataframe.id == read_experiment_dataframes[0].id
-    assert written_experiment_dataframe.data.equals(
-        read_experiment_dataframes[0].data
-    )
-    assert written_experiment_dataframe.tags == read_experiment_dataframes[0].tags
 
     rubicon.repository.filesystem.rm(rubicon.repository.root_dir, recursive=True)

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -64,10 +64,10 @@ def _create_dask_dataframe(repository, project=None):
         project = _create_project(repository)
     
     df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
-    dd.from_pandas(df, npartitions=1)
+    ddf = dd.from_pandas(df, npartitions=1)
 
     dataframe = domain.Dataframe(parent_id=project.id)
-    repository.create_dataframe(dataframe, df, project.name)
+    repository.create_dataframe(dataframe, ddf, project.name)
 
     return dataframe
 
@@ -483,7 +483,7 @@ def test_get_dask_dataframe(memory_repository):
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
 
     data = repository.get_dataframe_data(project.name, written_dataframe.id)
-    assert not data.empty
+    assert not data.compute().empty
 
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -363,22 +363,22 @@ def test_delete_artifact_throws_error_if_not_found(memory_repository):
 def test_persist_dataframe(mock_to_parquet, memory_repository):
     repository = memory_repository
     df = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
-    path = "/local/root"
+    path = "./local/root"
 
     # calls `BaseRepository._persist_dataframe` despite class using `MemoryRepository`
     super(MemoryRepository, repository)._persist_dataframe(df, path)
 
-    mock_to_parquet.assert_called_once_with(path, engine="pyarrow")
+    mock_to_parquet.assert_called_once_with(f"{path}/data.parquet", engine="pyarrow")
 
 @patch("pandas.read_parquet")
 def test_read_dataframe(mock_read_parquet, memory_repository):
     repository = memory_repository
-    path = "/local/root"
+    path = "./local/root"
 
     # calls `BaseRepository._read_dataframe` despite class using `MemoryRepository`
     super(MemoryRepository, repository)._read_dataframe(path)
 
-    mock_read_parquet.assert_called_once_with(path, engine="pyarrow")
+    mock_read_parquet.assert_called_once_with(f"{path}/data.parquet", engine="pyarrow")
 
 
 def test_get_dataframe_with_project_parent_root(memory_repository):

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -370,7 +370,7 @@ def test_persist_dataframe(mock_to_parquet, memory_repository):
 
     mock_to_parquet.assert_called_once_with(path, engine="pyarrow")
 
-@patch("dask.dataframe.read_parquet")
+@patch("pandas.read_parquet")
 def test_read_dataframe(mock_read_parquet, memory_repository):
     repository = memory_repository
     path = "/local/root"

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -50,7 +50,7 @@ def _create_pandas_dataframe(repository, project=None, dataframe_data=None, mult
         project = _create_project(repository)
 
     if dataframe_data is None:
-        dataframe_data = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+        dataframe_data = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
         if multi_index:
             dataframe_data = dataframe_data.set_index(['b', 'a']) # Set multiindex
 
@@ -63,7 +63,7 @@ def _create_dask_dataframe(repository, project=None):
     if project is None:
         project = _create_project(repository)
     
-    df = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+    df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
     dd.from_pandas(df, npartitions=1)
 
     dataframe = domain.Dataframe(parent_id=project.id)
@@ -456,15 +456,21 @@ def test_get_pandas_dataframe(memory_repository):
     written_dataframe = _create_pandas_dataframe(repository, project=project)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
 
+    data = repository.get_dataframe_data(project.name, written_dataframe.id)
+    assert not data.empty
+
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id
 
 
-def test_get_multi_index_dataframe(memory_repository):
+def test_get_pandas_multi_index_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
     written_dataframe = _create_pandas_dataframe(repository, project=project, multi_index=True)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    data = repository.get_dataframe_data(project.name, written_dataframe.id)
+    assert not data.empty
 
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id
@@ -475,6 +481,9 @@ def test_get_dask_dataframe(memory_repository):
     project = _create_project(repository)
     written_dataframe = _create_dask_dataframe(repository, project=project)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    data = repository.get_dataframe_data(project.name, written_dataframe.id)
+    assert not data.empty
 
     assert dataframe.id == written_dataframe.id
     assert dataframe.parent_id == written_dataframe.parent_id

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -50,26 +50,30 @@ def _create_pandas_dataframe(repository, project=None, dataframe_data=None, mult
         project = _create_project(repository)
 
     if dataframe_data is None:
-        dataframe_data = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
+        dataframe_data = pd.DataFrame(
+            [[0, 1, "a"], [1, 1, "b"], [2, 2, "c"], [3, 2, "d"]], columns=["a", "b", "c"]
+        )
         if multi_index:
-            dataframe_data = dataframe_data.set_index(['b', 'a']) # Set multiindex
+            dataframe_data = dataframe_data.set_index(["b", "a"])  # Set multiindex
 
     dataframe = domain.Dataframe(parent_id=project.id)
     repository.create_dataframe(dataframe, dataframe_data, project.name)
 
     return dataframe
 
+
 def _create_dask_dataframe(repository, project=None):
     if project is None:
         project = _create_project(repository)
-    
-    df = pd.DataFrame([[0,1,'a'],[1,1,'b'],[2,2,'c'],[3,2,'d']], columns=['a', 'b', 'c'])
+
+    df = pd.DataFrame([[0, 1, "a"], [1, 1, "b"], [2, 2, "c"], [3, 2, "d"]], columns=["a", "b", "c"])
     ddf = dd.from_pandas(df, npartitions=1)
 
     dataframe = domain.Dataframe(parent_id=project.id)
     repository.create_dataframe(dataframe, ddf, project.name)
 
     return dataframe
+
 
 def _create_feature(repository, experiment=None):
     if experiment is None:
@@ -370,6 +374,7 @@ def test_persist_dataframe(mock_to_parquet, memory_repository):
 
     mock_to_parquet.assert_called_once_with(f"{path}/data.parquet", engine="pyarrow")
 
+
 @patch("pandas.read_parquet")
 def test_read_dataframe(mock_read_parquet, memory_repository):
     repository = memory_repository
@@ -434,6 +439,7 @@ def test_create_pandas_multi_index_dataframe(memory_repository):
     assert repository.filesystem.exists(dataframe_data_path)
     assert dataframe.id == dataframe_json["id"]
 
+
 def test_create_dask_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
@@ -449,6 +455,7 @@ def test_create_dask_dataframe(memory_repository):
 
     assert repository.filesystem.exists(dataframe_data_path)
     assert dataframe.id == dataframe_json["id"]
+
 
 def test_get_pandas_dataframe(memory_repository):
     repository = memory_repository
@@ -503,7 +510,9 @@ def test_get_dataframe_throws_error_if_not_found(memory_repository):
 def test_get_dataframes(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    written_dataframes = [_create_pandas_dataframe(repository, project=project) for _ in range(0, 3)]
+    written_dataframes = [
+        _create_pandas_dataframe(repository, project=project) for _ in range(0, 3)
+    ]
     dataframes = repository.get_dataframes_metadata(project.name)
 
     dataframe_ids = [d.id for d in written_dataframes]

--- a/tests/unit/repository/test_base_repo.py
+++ b/tests/unit/repository/test_base_repo.py
@@ -45,18 +45,31 @@ def _create_artifact(repository, project=None, artifact_data=None):
     return artifact
 
 
-def _create_dataframe(repository, project=None, dataframe_data=None):
+def _create_pandas_dataframe(repository, project=None, dataframe_data=None, multi_index=False):
     if project is None:
         project = _create_project(repository)
 
     if dataframe_data is None:
         dataframe_data = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+        if multi_index:
+            dataframe_data = dataframe_data.set_index(['b', 'a']) # Set multiindex
 
     dataframe = domain.Dataframe(parent_id=project.id)
     repository.create_dataframe(dataframe, dataframe_data, project.name)
 
     return dataframe
 
+def _create_dask_dataframe(repository, project=None):
+    if project is None:
+        project = _create_project(repository)
+    
+    df = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
+    dd.from_pandas(df, npartitions=1)
+
+    dataframe = domain.Dataframe(parent_id=project.id)
+    repository.create_dataframe(dataframe, df, project.name)
+
+    return dataframe
 
 def _create_feature(repository, experiment=None):
     if experiment is None:
@@ -357,7 +370,6 @@ def test_persist_dataframe(mock_to_parquet, memory_repository):
 
     mock_to_parquet.assert_called_once_with(path, engine="pyarrow")
 
-
 @patch("dask.dataframe.read_parquet")
 def test_read_dataframe(mock_read_parquet, memory_repository):
     repository = memory_repository
@@ -389,10 +401,10 @@ def test_get_dataframe_with_experiment_parent_root(memory_repository):
     )
 
 
-def test_create_dataframe(memory_repository):
+def test_create_pandas_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project)
 
     dataframe_root = f"{repository.root_dir}/{slugify(project.name)}/dataframes/{dataframe.id}"
     dataframe_metadata_path = f"{dataframe_root}/metadata.json"
@@ -406,10 +418,62 @@ def test_create_dataframe(memory_repository):
     assert dataframe.id == dataframe_json["id"]
 
 
-def test_get_dataframe(memory_repository):
+def test_create_pandas_multi_index_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    written_dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project, multi_index=True)
+
+    dataframe_root = f"{repository.root_dir}/{slugify(project.name)}/dataframes/{dataframe.id}"
+    dataframe_metadata_path = f"{dataframe_root}/metadata.json"
+    dataframe_data_path = f"{dataframe_root}/data"
+
+    open_file = repository.filesystem.open(dataframe_metadata_path)
+    with open_file as f:
+        dataframe_json = json.load(f)
+
+    assert repository.filesystem.exists(dataframe_data_path)
+    assert dataframe.id == dataframe_json["id"]
+
+def test_create_dask_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    dataframe = _create_dask_dataframe(repository, project=project)
+
+    dataframe_root = f"{repository.root_dir}/{slugify(project.name)}/dataframes/{dataframe.id}"
+    dataframe_metadata_path = f"{dataframe_root}/metadata.json"
+    dataframe_data_path = f"{dataframe_root}/data"
+
+    open_file = repository.filesystem.open(dataframe_metadata_path)
+    with open_file as f:
+        dataframe_json = json.load(f)
+
+    assert repository.filesystem.exists(dataframe_data_path)
+    assert dataframe.id == dataframe_json["id"]
+
+def test_get_pandas_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    written_dataframe = _create_pandas_dataframe(repository, project=project)
+    dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    assert dataframe.id == written_dataframe.id
+    assert dataframe.parent_id == written_dataframe.parent_id
+
+
+def test_get_multi_index_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    written_dataframe = _create_pandas_dataframe(repository, project=project, multi_index=True)
+    dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
+
+    assert dataframe.id == written_dataframe.id
+    assert dataframe.parent_id == written_dataframe.parent_id
+
+
+def test_get_dask_dataframe(memory_repository):
+    repository = memory_repository
+    project = _create_project(repository)
+    written_dataframe = _create_dask_dataframe(repository, project=project)
     dataframe = repository.get_dataframe_metadata(project.name, written_dataframe.id)
 
     assert dataframe.id == written_dataframe.id
@@ -430,7 +494,7 @@ def test_get_dataframe_throws_error_if_not_found(memory_repository):
 def test_get_dataframes(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    written_dataframes = [_create_dataframe(repository, project=project) for _ in range(0, 3)]
+    written_dataframes = [_create_pandas_dataframe(repository, project=project) for _ in range(0, 3)]
     dataframes = repository.get_dataframes_metadata(project.name)
 
     dataframe_ids = [d.id for d in written_dataframes]
@@ -453,7 +517,7 @@ def test_get_dataframe_data(memory_repository):
     dataframe_data = pd.DataFrame([[0, 1], [1, 0]], columns=["a", "b"])
     dataframe_data = dd.from_pandas(dataframe_data, npartitions=1)
 
-    dataframe = _create_dataframe(repository, project=project, dataframe_data=dataframe_data)
+    dataframe = _create_pandas_dataframe(repository, project=project, dataframe_data=dataframe_data)
     data = repository.get_dataframe_data(project.name, dataframe.id)
 
     assert dataframe_data.compute().equals(data.compute())
@@ -473,7 +537,7 @@ def test_get_dataframe_data_throws_error_if_not_found(memory_repository):
 def test_delete_dataframe(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project)
 
     repository.delete_dataframe(project.name, dataframe.id)
 
@@ -731,7 +795,7 @@ def test_get_experiment_tags_root(memory_repository):
 def test_get_dataframe_tags_with_project_parent_root(memory_repository):
     repository = memory_repository
     project = _create_project(repository)
-    dataframe = _create_dataframe(repository, project=project)
+    dataframe = _create_pandas_dataframe(repository, project=project)
     dataframe_tags_root = repository._get_tag_metadata_root(project.name, dataframe_id=dataframe.id)
 
     assert (


### PR DESCRIPTION
closes: #47 

---

## What

Support logging either `pandas` or `dask` dataframes because as #47 points out, there are cases where pandas dfs are incompatible with dask. 

* pandas dataframes will be logged to a single parquet file
* dask dataframes are automatically split into separate parquet files based on minimum file sizes

* read the dfs back with `rubicon.Dataframe.get_data()`

## How to Test

* make sure that the new tests handle all the different cases

## TODO

- [x] update the async counterparts
- [x] fix formatting issues

- [x] mark `rubicon.Dataframe.data` as deprecated