### PR TITLE
don't write empty files

### DIFF
--- a/rubicon/repository/local.py
+++ b/rubicon/repository/local.py
@@ -30,12 +30,9 @@ class LocalRepository(BaseRepository):
         """Persists the Rubicon object `domain` to the local
         path defined by `path`.
         """
-        try:
-            json_domain = json.dumps(domain)
-        except TypeError as e:
-            raise e
-        else:
-            self.filesystem.mkdirs(os.path.dirname(path), exist_ok=True)
+        json_domain = json.dumps(domain)
 
-            with self.filesystem.open(path, "w") as f:
-                f.write(json_domain)
+        self.filesystem.mkdirs(os.path.dirname(path), exist_ok=True)
+
+        with self.filesystem.open(path, "w") as f:
+            f.write(json_domain)

--- a/rubicon/repository/local.py
+++ b/rubicon/repository/local.py
@@ -30,7 +30,12 @@ class LocalRepository(BaseRepository):
         """Persists the Rubicon object `domain` to the local
         path defined by `path`.
         """
-        self.filesystem.mkdirs(os.path.dirname(path), exist_ok=True)
+        try:
+            json_domain = json.dumps(domain)
+        except TypeError as e:
+            raise e
+        else:
+            self.filesystem.mkdirs(os.path.dirname(path), exist_ok=True)
 
-        with self.filesystem.open(path, "w") as f:
-            f.write(json.dumps(domain))
+            with self.filesystem.open(path, "w") as f:
+                f.write(json_domain)

--- a/rubicon/repository/s3.py
+++ b/rubicon/repository/s3.py
@@ -29,10 +29,7 @@ class S3Repository(BaseRepository):
         """Persists the Rubicon object `domain` to the S3
         bucket defined by `path`.
         """
-        try:
-            json_domain = json.dumps(domain)
-        except TypeError as e:
-            raise e
-        else:
-            with self.filesystem.open(path, "w") as f:
-                f.write(json_domain)
+        json_domain = json.dumps(domain)
+
+        with self.filesystem.open(path, "w") as f:
+            f.write(json_domain)

--- a/rubicon/repository/s3.py
+++ b/rubicon/repository/s3.py
@@ -29,5 +29,10 @@ class S3Repository(BaseRepository):
         """Persists the Rubicon object `domain` to the S3
         bucket defined by `path`.
         """
-        with self.filesystem.open(path, "w") as f:
-            f.write(json.dumps(domain))
+        try:
+            json_domain = json.dumps(domain)
+        except TypeError as e:
+            raise e
+        else:
+            with self.filesystem.open(path, "w") as f:
+                f.write(json_domain)

--- a/tests/unit/repository/test_local_repo.py
+++ b/tests/unit/repository/test_local_repo.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import uuid
 from unittest.mock import patch
 
@@ -40,3 +41,19 @@ def test_persist_domain(mock_mkdirs, mock_open):
 
     mock_mkdirs.assert_called_once_with(os.path.dirname(project_metadata_path), exist_ok=True)
     mock_open.assert_called_once_with(project_metadata_path, "w")
+
+
+@patch("fsspec.implementations.local.LocalFileSystem.open")
+@patch("fsspec.implementations.local.LocalFileSystem.mkdirs")
+def test_persist_domain_throws_error(mock_mkdirs, mock_open):
+    not_serializable = str
+
+    project = domain.Project(f"Test Project {uuid.uuid4()}", description=not_serializable)
+    project_metadata_path = f"/local/root/{slugify(project.name)}/metadata.json"
+
+    local_repo = LocalRepository(root_dir="/local/root")
+    with pytest.raises(TypeError):
+        local_repo._persist_domain(project, project_metadata_path)
+
+    mock_mkdirs.assert_not_called()
+    mock_open.assert_not_called()

--- a/tests/unit/repository/test_local_repo.py
+++ b/tests/unit/repository/test_local_repo.py
@@ -1,9 +1,9 @@
 import os
-import pytest
 import uuid
 from unittest.mock import patch
 
 import fsspec
+import pytest
 
 from rubicon import domain
 from rubicon.repository import LocalRepository

--- a/tests/unit/repository/test_s3_repo.py
+++ b/tests/unit/repository/test_s3_repo.py
@@ -1,7 +1,7 @@
-import pytest
 import uuid
 from unittest.mock import patch
 
+import pytest
 import s3fs
 
 from rubicon import domain

--- a/tests/unit/repository/test_s3_repo.py
+++ b/tests/unit/repository/test_s3_repo.py
@@ -1,3 +1,4 @@
+import pytest
 import uuid
 from unittest.mock import patch
 
@@ -35,3 +36,17 @@ def test_persist_domain(mock_open):
     s3_repo._persist_domain(project, project_metadata_path)
 
     mock_open.assert_called_once_with(project_metadata_path, "w")
+
+
+@patch("s3fs.core.S3FileSystem.open")
+def test_persist_domain_throws_error(mock_open):
+    not_serializable = str
+
+    project = domain.Project(f"Test Project {uuid.uuid4()}", description=not_serializable)
+    project_metadata_path = f"s3://bucket/root/{slugify(project.name)}/metadata.json"
+
+    s3_repo = S3Repository(root_dir="s3://bucket/root")
+    with pytest.raises(TypeError):
+        s3_repo._persist_domain(project, project_metadata_path)
+
+    mock_open.assert_not_called()


### PR DESCRIPTION
closes: #56 

---

## What
  * checks that json is valid in writes before any filesystem operations take place
    * both S3 and local - memory inherits behavior from local
  * adds tests

## How to Test
  * validate the example in #56 no longer throws the second error
