### PR TITLE
Support hiding cols within experiment table and comparison plot

### DIFF
--- a/rubicon/ui/assets/css/project-explorer.css
+++ b/rubicon/ui/assets/css/project-explorer.css
@@ -55,3 +55,39 @@
     background-color: rgba(0, 0, 0, 0);
     margin-left: auto;
 }
+
+.dash-table-container {
+    /* make the action btns line up */
+    margin-top: -40px;
+}
+
+.show-hide {
+    box-shadow: none;
+    box-sizing: border-box;
+    font-weight: 400;
+    font-family: Optimist, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    cursor: pointer;
+    white-space: nowrap;
+    color: #ffffff;
+    background-color: #0D74AF;
+    font-size: 14px;
+    line-height: 2;
+    border-width: initial;
+    border-style: none;
+    border-color: initial;
+    border-image: initial;
+    text-decoration: none;
+    margin: 0px;
+    outline: none;
+    padding: 0px 16px;
+    border-radius: 4px;
+    margin-bottom: 6px;
+}
+
+.dash-spreadsheet-menu {
+    justify-content: flex-end;
+}
+
+.dash-spreadsheet-container .dash-spreadsheet {
+    margin-top: 8px;
+}

--- a/rubicon/ui/assets/css/project-explorer.css
+++ b/rubicon/ui/assets/css/project-explorer.css
@@ -84,6 +84,12 @@
     margin-bottom: 6px;
 }
 
+.show-hide-menu .show-hide-menu-item, input {
+    margin-top: 6px;
+    margin-right: 6px;
+}
+
+
 .dash-spreadsheet-menu {
     justify-content: flex-end;
 }

--- a/rubicon/ui/assets/css/shared.css
+++ b/rubicon/ui/assets/css/shared.css
@@ -30,6 +30,7 @@ a:hover {
     width: 180px;
     display: flex;
     justify-content: space-between;
+    z-index: 999;
 }
 
 .btn-progressive {

--- a/rubicon/ui/model.py
+++ b/rubicon/ui/model.py
@@ -60,7 +60,7 @@ class RubiconModel:
 
         return [{"label": a, "value": a} for a in anchors]
 
-    def get_dimensions(self, commit_hash, selected_experiment_ids, anchor):
+    def get_dimensions(self, commit_hash, selected_experiment_ids, hidden_columns, anchor):
         """Collects and cleans the data necessary to render the Dash parallel
         coordinates plot representing an experiment comparison plot.
 
@@ -72,6 +72,8 @@ class RubiconModel:
             The experiment ID's of the group of experiments to get dimensions
             for. Not all experiments in a group have to be shown on the
             comparison plot.
+        hidden_columns : List of columns ids of the columns that are currently
+            hidden.
         anchor : str
             The currently selected anchor metric. The anchor metric should be
             represented by the last dimension.
@@ -86,8 +88,10 @@ class RubiconModel:
         """
         dimensions = []
 
-        experiment_comparison_root_df = self.get_experiment_comparison_root_df(commit_hash)
-        experiment_comparison_df = experiment_comparison_root_df.loc[selected_experiment_ids]
+        root_df = self.get_experiment_comparison_root_df(commit_hash)
+        # ignore errors since some of the hidden cols could already be dropped, like `id`
+        root_dropped_hidden_df = root_df.drop(columns=hidden_columns, errors="ignore")
+        experiment_comparison_df = root_dropped_hidden_df.loc[selected_experiment_ids]
         experiment_comparison_df = experiment_comparison_df.compute().convert_dtypes()
 
         for column in experiment_comparison_df.columns:

--- a/rubicon/ui/model.py
+++ b/rubicon/ui/model.py
@@ -89,9 +89,10 @@ class RubiconModel:
         dimensions = []
 
         root_df = self.get_experiment_comparison_root_df(commit_hash)
-        # ignore errors since some of the hidden cols could already be dropped, like `id`
-        root_dropped_hidden_df = root_df.drop(columns=hidden_columns, errors="ignore")
-        experiment_comparison_df = root_dropped_hidden_df.loc[selected_experiment_ids]
+        if hidden_columns is not None:
+            # ignore errors since some of the hidden cols could already be dropped, like `id`
+            root_df = root_df.drop(columns=hidden_columns, errors="ignore")
+        experiment_comparison_df = root_df.loc[selected_experiment_ids]
         experiment_comparison_df = experiment_comparison_df.compute().convert_dtypes()
 
         for column in experiment_comparison_df.columns:

--- a/rubicon/ui/views/project_explorer.py
+++ b/rubicon/ui/views/project_explorer.py
@@ -18,7 +18,10 @@ def _get_experiment_table(id, experiments_df):
     """Get a Dash DataTable with the experiments in `experiments_df`."""
     return dash_table.DataTable(
         id={"type": "experiment-table", "index": id},
-        columns=[{"name": i, "id": i, "selectable": True} for i in experiments_df.columns],
+        columns=[
+            {"name": i, "id": i, "selectable": True, "hideable": True}
+            for i in experiments_df.columns
+        ],
         data=experiments_df.compute().to_dict("records"),
         page_size=10,
         filter_action="native",
@@ -260,12 +263,13 @@ def _toggle_experiment_group_collapsable(last_show_click, last_hide_click):
     [
         Input({"type": "experiment-table", "index": MATCH}, "derived_virtual_data"),
         Input({"type": "experiment-table", "index": MATCH}, "derived_virtual_selected_rows"),
+        Input({"type": "experiment-table", "index": MATCH}, "hidden_columns"),
         Input({"type": "anchor-dropdown", "index": MATCH}, "value"),
     ],
     [State({"type": "group-store", "index": MATCH}, "data")],
 )
 def _update_experiment_comparison_plot(
-    experiment_table_data, experiment_table_selected_rows, anchor, data
+    experiment_table_data, experiment_table_selected_rows, hidden_columns, anchor, data
 ):
     """The callback to render a new experiment comparison plot.
 
@@ -281,7 +285,7 @@ def _update_experiment_comparison_plot(
     ]
 
     anchor_data, dimensions = app._rubicon_model.get_dimensions(
-        commit_hash, selected_experiment_ids, anchor
+        commit_hash, selected_experiment_ids, hidden_columns, anchor
     )
 
     return [

--- a/tests/integration/test_dashboard.py
+++ b/tests/integration/test_dashboard.py
@@ -133,6 +133,7 @@ def test_individual_project_explorer_view(dashboard_setup, dash_duo):
     assert group_detail_view.find_element_by_class_name("experiment-comparison-header")
     assert group_detail_view.find_element_by_class_name("anchor-dropdown")
     assert group_detail_view.find_element_by_class_name("experiment-comparison-plot")
+    assert group_detail_view.find_element_by_class_name("show-hide")
 
     # click the select all btn
     action_btn_group = group_detail_view.find_element_by_class_name("btn-group")


### PR DESCRIPTION
closes: #55 

---

## What

Adds support to hide columns from within the experiment table. Any col hidden there, will also be removed from the experiment comparison plot. We've seen that plot look extremely cluttered when there are lots of params/metrics so hopefully this is a good solution to declutter easily.

## How to Test

* Check out the dashboard functionality
* Run the dashboard integration tests - note you may have to upgrade `chromedriver`: `brew upgrade chromedriver`
