### PR TITLE
support specifying page-size on dashboard startup

### DIFF
--- a/rubicon/cli.py
+++ b/rubicon/cli.py
@@ -20,6 +20,13 @@ def cli():
     required=True,
 )
 @click.option(
+    "--page-size",
+    "-ps",
+    type=click.INT,
+    help="The number of rows that will be displayed on a page within the experiment table.",
+    default=10,
+)
+@click.option(
     "--host", "-h", type=click.STRING, help="The host to serve the dashboard on.", default=None
 )
 @click.option(
@@ -27,13 +34,6 @@ def cli():
 )
 @click.option(
     "--debug", "-d", type=click.BOOL, help="Whether or not to run in debug mode.", default=False
-)
-@click.option(
-    "--page-size",
-    "-ps",
-    type=click.INT,
-    help="The number of rows that will be displayed on a page within the experiment table.",
-    default=10,
 )
 def ui(root_dir, host, port, debug, page_size):
     """Launch the Rubicon Dashboard."""

--- a/rubicon/cli.py
+++ b/rubicon/cli.py
@@ -28,9 +28,16 @@ def cli():
 @click.option(
     "--debug", "-d", type=click.BOOL, help="Whether or not to run in debug mode.", default=False
 )
-def ui(root_dir, host, port, debug):
+@click.option(
+    "--page-size",
+    "-ps",
+    type=click.INT,
+    help="The number of rows that will be displayed on a page within the experiment table.",
+    default=10,
+)
+def ui(root_dir, host, port, debug, page_size):
     """Launch the Rubicon Dashboard."""
-    dashboard = Dashboard("filesystem", root_dir)
+    dashboard = Dashboard("filesystem", root_dir, page_size=page_size)
 
     server_kwargs = dict(debug=debug, port=port, host=host)
     server_kwargs = {k: v for k, v in server_kwargs.items() if v is not None}

--- a/rubicon/cli.py
+++ b/rubicon/cli.py
@@ -22,7 +22,7 @@ def cli():
 @click.option(
     "--page-size",
     "-ps",
-    type=click.INT,
+    type=click.IntRange(min=1),
     help="The number of rows that will be displayed on a page within the experiment table.",
     default=10,
 )

--- a/rubicon/ui/dashboard.py
+++ b/rubicon/ui/dashboard.py
@@ -20,10 +20,14 @@ class Dashboard:
         Absolute or relative filepath of the root directory holding Rubicon data.
         Use absolute path for best performance. Defaults to the local filesystem.
         Prefix with s3:// to use s3 instead.
+    page_size : int, optional
+        The number of rows that will be displayed on a page within the
+        experiment table.
     """
 
-    def __init__(self, persistence, root_dir=None):
+    def __init__(self, persistence, root_dir=None, page_size=10):
         self._app = app
+        self._app._page_size = page_size
         self.rubicon_model = RubiconModel(persistence, root_dir)
         self._app._rubicon_model = self.rubicon_model
 

--- a/rubicon/ui/views/project_explorer.py
+++ b/rubicon/ui/views/project_explorer.py
@@ -23,7 +23,7 @@ def _get_experiment_table(id, experiments_df):
             for i in experiments_df.columns
         ],
         data=experiments_df.compute().to_dict("records"),
-        page_size=10,
+        page_size=app._page_size,
         filter_action="native",
         sort_action="native",
         sort_mode="multi",


### PR DESCRIPTION
closes: #54 

---

## What
  * Add a cli param to specify the page size of the experiment table so it's more flexible based on user perference

## How to Test
  * Try different page sizes 

```
rubicon ui --help
Usage: rubicon ui [OPTIONS]

  Launch the Rubicon Dashboard.

Options:
  --root-dir TEXT           The absolute path to the top level folder holding
                            the Rubicon project(s).  [required]

  -ps, --page-size INTEGER  The number of rows that will be displayed on a
                            page within the experiment table.

  -h, --host TEXT           The host to serve the dashboard on.
  -p, --port TEXT           The port to serve the dashboard on.
  -d, --debug BOOLEAN       Whether or not to run in debug mode.
  --help                    Show this message and exit.
```
