### PR TITLE
don't log empty experiments

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -18,6 +18,9 @@ dependencies:
   # required for prefect workflows
   - prefect>=0.12.0
 
+  # required for scikit-learn integration
+  - scikit-learn
+
   # required for UI (including testing)
   - beautifulsoup4>=4.8.2
   - dash>=1.14.0

--- a/notebooks/sklearn-integration.ipynb
+++ b/notebooks/sklearn-integration.ipynb
@@ -205,7 +205,7 @@
     "    \"clf__penalty\": (\"l2\", \"elasticnet\"),\n",
     "}\n",
     "\n",
-    "grid_search = GridSearchCV(pipeline, parameters, cv=2, n_jobs=-1, verbose=1)\n",
+    "grid_search = GridSearchCV(pipeline, parameters, cv=2, n_jobs=-1, refit=False, verbose=1)\n",
     "\n",
     "print(\"Performing grid search...\")\n",
     "print(\"RubiconPipeline:\", [name for name, *_ in pipeline.steps])\n",
@@ -282,7 +282,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What
  * stops the pipeline from logging empty experiments
    * the one with only no score was caused by refitting at the end of the grid search, so it totally makes sense that that experiment didn't have a score since it was only fit. I just set `refit=False` for the sake of the example.
    * the totally empty ones were made because sklearn loves to copy estimators all over the place and sometimes doesn't run anything on the copies.
      * to fix this I moved the experiment instantiation to the `fit` call rather than the initialization
      * I'm pretty sure sklearn will yell at you first if you try to call score without calling fit, but I provided an experiment passthrough on the `score` method in case theres some case you'd wanna do that in

## How to Test
  * run the notebook and validate that all the experiments have data on the dashboard
