### PR TITLE
82 handle misc files or folders

### DIFF
--- a/rubicon/repository/asynchronous/base.py
+++ b/rubicon/repository/asynchronous/base.py
@@ -157,11 +157,14 @@ class AsynchronousBaseRepository(BaseRepository):
         """
         try:
             project_metadata_paths = await self._ls_directories_only(self.root_dir)
+            cat = await self.filesystem._cat(project_metadata_paths, on_error="return")
+
             projects = [
-                domain.Project(**json.loads(data))
-                for data in await asyncio.gather(
-                    *[self.filesystem._cat_file(path) for path in project_metadata_paths]
-                )
+                domain.Project(**json.loads(metadata))
+                for metadata in cat.values()
+                # skip FileNotFound errors rather than raising them and preventing the rest of the
+                # files to be read by rubicon
+                if not isinstance(metadata, FileNotFoundError)
             ]
         except FileNotFoundError:
             return []
@@ -236,11 +239,12 @@ class AsynchronousBaseRepository(BaseRepository):
 
         try:
             experiment_metadata_paths = await self._ls_directories_only(experiment_metadata_root)
+            cat = await self.filesystem._cat(experiment_metadata_paths, on_error="return")
+
             experiments = [
-                domain.Experiment(**json.loads(data))
-                for data in await asyncio.gather(
-                    *[self.filesystem._cat_file(path) for path in experiment_metadata_paths]
-                )
+                domain.Experiment(**json.loads(metadata))
+                for metadata in cat.values()
+                if not isinstance(metadata, FileNotFoundError)
             ]
         except FileNotFoundError:
             return []
@@ -331,11 +335,12 @@ class AsynchronousBaseRepository(BaseRepository):
 
         try:
             feature_metadata_paths = await self._ls_directories_only(feature_metadata_root)
+            cat = await self.filesystem._cat(feature_metadata_paths, on_error="return")
+
             features = [
-                domain.Feature(**json.loads(data))
-                for data in await asyncio.gather(
-                    *[self.filesystem._cat_file(path) for path in feature_metadata_paths]
-                )
+                domain.Feature(**json.loads(metadata))
+                for metadata in cat.values()
+                if not isinstance(metadata, FileNotFoundError)
             ]
         except FileNotFoundError:
             return []
@@ -425,11 +430,12 @@ class AsynchronousBaseRepository(BaseRepository):
 
         try:
             parameter_metadata_paths = await self._ls_directories_only(parameter_metadata_root)
+            cat = await self.filesystem._cat(parameter_metadata_paths, on_error="return")
+
             parameters = [
-                domain.Parameter(**json.loads(data))
-                for data in await asyncio.gather(
-                    *[self.filesystem._cat_file(path) for path in parameter_metadata_paths]
-                )
+                domain.Parameter(**json.loads(metadata))
+                for metadata in cat.values()
+                if not isinstance(metadata, FileNotFoundError)
             ]
         except FileNotFoundError:
             return []
@@ -519,11 +525,12 @@ class AsynchronousBaseRepository(BaseRepository):
 
         try:
             metric_metadata_paths = await self._ls_directories_only(metric_metadata_root)
+            cat = await self.filesystem._cat(metric_metadata_paths, on_error="return")
+
             metrics = [
-                domain.Metric(**json.loads(data))
-                for data in await asyncio.gather(
-                    *[self.filesystem._cat_file(path) for path in metric_metadata_paths]
-                )
+                domain.Metric(**json.loads(metadata))
+                for metadata in cat.values()
+                if not isinstance(metadata, FileNotFoundError)
             ]
         except FileNotFoundError:
             return []
@@ -620,11 +627,12 @@ class AsynchronousBaseRepository(BaseRepository):
 
         try:
             dataframe_metadata_paths = await self._ls_directories_only(dataframe_metadata_root)
+            cat = await self.filesystem._cat(dataframe_metadata_paths, on_error="return")
+
             dataframes = [
-                domain.Dataframe(**json.loads(data))
-                for data in await asyncio.gather(
-                    *[self.filesystem._cat_file(path) for path in dataframe_metadata_paths]
-                )
+                domain.Dataframe(**json.loads(metadata))
+                for metadata in cat.values()
+                if not isinstance(metadata, FileNotFoundError)
             ]
         except FileNotFoundError:
             return []
@@ -745,11 +753,12 @@ class AsynchronousBaseRepository(BaseRepository):
 
         try:
             artifact_metadata_paths = await self._ls_directories_only(artifact_metadata_root)
+            cat = await self.filesystem._cat(artifact_metadata_paths, on_error="return")
+
             artifacts = [
-                domain.Artifact(**json.loads(data))
-                for data in await asyncio.gather(
-                    *[self.filesystem._cat_file(path) for path in artifact_metadata_paths]
-                )
+                domain.Artifact(**json.loads(metadata))
+                for metadata in cat.values()
+                if not isinstance(metadata, FileNotFoundError)
             ]
         except FileNotFoundError:
             return []

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -99,16 +99,17 @@ class BaseRepository:
         """
         try:
             project_metadata_paths = self._ls_directories_only(self.root_dir)
+            projects = [
+                domain.Project(**json.loads(metadata))
+                for metadata in self.filesystem.cat(
+                    project_metadata_paths, on_error="return"
+                ).values()
+                # skip FileNotFound errors rather than raising them and preventing the rest of the
+                # files to be read by rubicon
+                if not isinstance(metadata, FileNotFoundError)
+            ]
         except FileNotFoundError:
             return []
-
-        projects = [
-            domain.Project(**json.loads(metadata))
-            for metadata in self.filesystem.cat(project_metadata_paths, on_error="return").values()
-            # skip FileNotFound errors rather than raising them and preventing the rest of the
-            # files to be read by rubicon
-            if not isinstance(metadata, FileNotFoundError)
-        ]
 
         return projects
 
@@ -190,14 +191,15 @@ class BaseRepository:
 
         try:
             experiment_metadata_paths = self._ls_directories_only(experiment_metadata_root)
+            experiments = [
+                domain.Experiment(**json.loads(metadata))
+                for metadata in self.filesystem.cat(
+                    experiment_metadata_paths, on_error="return"
+                ).values()
+                if not isinstance(metadata, FileNotFoundError)
+            ]
         except FileNotFoundError:
             return []
-
-        experiments = [
-            domain.Experiment(**json.loads(metadata))
-            for metadata in self.filesystem.cat(experiment_metadata_paths, on_error="return").values()
-            if not isinstance(metadata, FileNotFoundError)
-        ]
 
         return experiments
 
@@ -310,14 +312,15 @@ class BaseRepository:
 
         try:
             artifact_metadata_paths = self._ls_directories_only(artifact_metadata_root)
+            artifacts = [
+                domain.Artifact(**json.loads(metadata))
+                for metadata in self.filesystem.cat(
+                    artifact_metadata_paths, on_error="return"
+                ).values()
+                if not isinstance(metadata, FileNotFoundError)
+            ]
         except FileNotFoundError:
             return []
-
-        artifacts = [
-            domain.Artifact(**json.loads(metadata))
-            for metadata in self.filesystem.cat(artifact_metadata_paths, on_error="return").values()
-            if not isinstance(metadata, FileNotFoundError)
-        ]
 
         return artifacts
 
@@ -514,14 +517,15 @@ class BaseRepository:
 
         try:
             dataframe_metadata_paths = self._ls_directories_only(dataframe_metadata_root)
+            dataframes = [
+                domain.Dataframe(**json.loads(metadata))
+                for metadata in self.filesystem.cat(
+                    dataframe_metadata_paths, on_error="return"
+                ).values()
+                if not isinstance(metadata, FileNotFoundError)
+            ]
         except FileNotFoundError:
             return []
-
-        dataframes = [
-            domain.Dataframe(**json.loads(metadata))
-            for metadata in self.filesystem.cat(dataframe_metadata_paths, on_error="return").values()
-            if not isinstance(metadata, FileNotFoundError)
-        ]
 
         return dataframes
 
@@ -679,14 +683,15 @@ class BaseRepository:
 
         try:
             feature_metadata_paths = self._ls_directories_only(feature_metadata_root)
+            features = [
+                domain.Feature(**json.loads(metadata))
+                for metadata in self.filesystem.cat(
+                    feature_metadata_paths, on_error="return"
+                ).values()
+                if not isinstance(metadata, FileNotFoundError)
+            ]
         except FileNotFoundError:
             return []
-
-        features = [
-            domain.Feature(**json.loads(metadata))
-            for metadata in self.filesystem.cat(feature_metadata_paths, on_error="return").values()
-            if not isinstance(metadata, FileNotFoundError)
-        ]
 
         return features
 
@@ -786,14 +791,15 @@ class BaseRepository:
 
         try:
             metric_metadata_paths = self._ls_directories_only(metric_metadata_root)
+            metrics = [
+                domain.Metric(**json.loads(metadata))
+                for metadata in self.filesystem.cat(
+                    metric_metadata_paths, on_error="return"
+                ).values()
+                if not isinstance(metadata, FileNotFoundError)
+            ]
         except FileNotFoundError:
             return []
-
-        metrics = [
-            domain.Metric(**json.loads(metadata))
-            for metadata in self.filesystem.cat(metric_metadata_paths, on_error="return").values()
-            if not isinstance(metadata, FileNotFoundError)
-        ]
 
         return metrics
 
@@ -891,14 +897,15 @@ class BaseRepository:
         parameter_metadata_root = self._get_parameter_metadata_root(project_name, experiment_id)
         try:
             parameter_metadata_paths = self._ls_directories_only(parameter_metadata_root)
+            parameters = [
+                domain.Parameter(**json.loads(metadata))
+                for metadata in self.filesystem.cat(
+                    parameter_metadata_paths, on_error="return"
+                ).values()
+                if not isinstance(metadata, FileNotFoundError)
+            ]
         except FileNotFoundError:
             return []
-
-        parameters = [
-            domain.Parameter(**json.loads(metadata))
-            for metadata in self.filesystem.cat(parameter_metadata_paths, on_error="return").values()
-            if not isinstance(metadata, FileNotFoundError)
-        ]
 
         return parameters
 

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -99,12 +99,16 @@ class BaseRepository:
         """
         try:
             project_metadata_paths = self._ls_directories_only(self.root_dir)
-            projects = [
-                domain.Project(**json.loads(metadata))
-                for metadata in self.filesystem.cat(project_metadata_paths).values()
-            ]
         except FileNotFoundError:
             return []
+
+        projects = [
+            domain.Project(**json.loads(metadata))
+            for metadata in self.filesystem.cat(project_metadata_paths, on_error="return").values()
+            # skip FileNotFound errors rather than raising them and preventing the rest of the
+            # files to be read by rubicon
+            if not isinstance(metadata, FileNotFoundError)
+        ]
 
         return projects
 
@@ -186,12 +190,14 @@ class BaseRepository:
 
         try:
             experiment_metadata_paths = self._ls_directories_only(experiment_metadata_root)
-            experiments = [
-                domain.Experiment(**json.loads(data))
-                for data in self.filesystem.cat(experiment_metadata_paths).values()
-            ]
         except FileNotFoundError:
             return []
+
+        experiments = [
+            domain.Experiment(**json.loads(metadata))
+            for metadata in self.filesystem.cat(experiment_metadata_paths, on_error="return").values()
+            if not isinstance(metadata, FileNotFoundError)
+        ]
 
         return experiments
 
@@ -304,12 +310,14 @@ class BaseRepository:
 
         try:
             artifact_metadata_paths = self._ls_directories_only(artifact_metadata_root)
-            artifacts = [
-                domain.Artifact(**json.loads(data))
-                for data in self.filesystem.cat(artifact_metadata_paths).values()
-            ]
         except FileNotFoundError:
             return []
+
+        artifacts = [
+            domain.Artifact(**json.loads(metadata))
+            for metadata in self.filesystem.cat(artifact_metadata_paths, on_error="return").values()
+            if not isinstance(metadata, FileNotFoundError)
+        ]
 
         return artifacts
 
@@ -506,12 +514,14 @@ class BaseRepository:
 
         try:
             dataframe_metadata_paths = self._ls_directories_only(dataframe_metadata_root)
-            dataframes = [
-                domain.Dataframe(**json.loads(data))
-                for data in self.filesystem.cat(dataframe_metadata_paths).values()
-            ]
         except FileNotFoundError:
             return []
+
+        dataframes = [
+            domain.Dataframe(**json.loads(metadata))
+            for metadata in self.filesystem.cat(dataframe_metadata_paths, on_error="return").values()
+            if not isinstance(metadata, FileNotFoundError)
+        ]
 
         return dataframes
 
@@ -669,12 +679,14 @@ class BaseRepository:
 
         try:
             feature_metadata_paths = self._ls_directories_only(feature_metadata_root)
-            features = [
-                domain.Feature(**json.loads(data))
-                for data in self.filesystem.cat(feature_metadata_paths).values()
-            ]
         except FileNotFoundError:
             return []
+
+        features = [
+            domain.Feature(**json.loads(metadata))
+            for metadata in self.filesystem.cat(feature_metadata_paths, on_error="return").values()
+            if not isinstance(metadata, FileNotFoundError)
+        ]
 
         return features
 
@@ -774,12 +786,14 @@ class BaseRepository:
 
         try:
             metric_metadata_paths = self._ls_directories_only(metric_metadata_root)
-            metrics = [
-                domain.Metric(**json.loads(data))
-                for data in self.filesystem.cat(metric_metadata_paths).values()
-            ]
         except FileNotFoundError:
             return []
+
+        metrics = [
+            domain.Metric(**json.loads(metadata))
+            for metadata in self.filesystem.cat(metric_metadata_paths, on_error="return").values()
+            if not isinstance(metadata, FileNotFoundError)
+        ]
 
         return metrics
 
@@ -875,15 +889,16 @@ class BaseRepository:
             `experiment_id`.
         """
         parameter_metadata_root = self._get_parameter_metadata_root(project_name, experiment_id)
-
         try:
             parameter_metadata_paths = self._ls_directories_only(parameter_metadata_root)
-            parameters = [
-                domain.Parameter(**json.loads(data))
-                for data in self.filesystem.cat(parameter_metadata_paths).values()
-            ]
         except FileNotFoundError:
             return []
+
+        parameters = [
+            domain.Parameter(**json.loads(metadata))
+            for metadata in self.filesystem.cat(parameter_metadata_paths, on_error="return").values()
+            if not isinstance(metadata, FileNotFoundError)
+        ]
 
         return parameters
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -103,6 +103,16 @@ def rubicon_local_filesystem_client():
 
 
 @pytest.fixture
+def rubicon_local_filesystem_client_with_project(rubicon_local_filesystem_client):
+    rubicon = rubicon_local_filesystem_client
+
+    project_name = "Test Project"
+    project = rubicon.get_or_create_project(project_name, description="testing.")
+
+    return rubicon, project
+
+
+@pytest.fixture
 def project_client(rubicon_client):
     """Setup an instance of rubicon configured to log to memory
     with a default project and clean it up afterwards.

--- a/tests/integration/test_rubicon_misc.py
+++ b/tests/integration/test_rubicon_misc.py
@@ -5,7 +5,7 @@ from pathlib import Path
 def test_rubicon_with_misc_folders_at_project_level(rubicon_local_filesystem_client_with_project):
     rubicon, project = rubicon_local_filesystem_client_with_project
 
-    os.makedirs(os.path.join(rubicon.config.root_dir, project.name, ".ipynb_checkpoints"))
+    os.makedirs(os.path.join(rubicon.config.root_dir, "test-project", ".ipynb_checkpoints"))
     os.makedirs(os.path.join(rubicon.config.root_dir, "test"))
 
     assert len(rubicon.projects()) == 1

--- a/tests/integration/test_rubicon_misc.py
+++ b/tests/integration/test_rubicon_misc.py
@@ -1,0 +1,71 @@
+import os
+from pathlib import Path
+
+
+def test_rubicon_with_misc_folders_at_project_level(rubicon_local_filesystem_client_with_project):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    os.makedirs(os.path.join(rubicon.config.root_dir, project.name, ".ipynb_checkpoints"))
+    os.makedirs(os.path.join(rubicon.config.root_dir, "test"))
+
+    assert len(rubicon.projects()) == 1
+
+
+def test_rubicon_with_misc_files_at_project_level(rubicon_local_filesystem_client_with_project):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    Path(os.path.join(rubicon.config.root_dir, "file.txt")).touch()
+
+    assert len(rubicon.projects()) == 1
+
+
+def test_rubicon_with_misc_folders_at_sublevel_level(rubicon_local_filesystem_client_with_project):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    project.log_experiment("exp1")
+    project.log_experiment("exp2")
+
+    os.makedirs(
+        os.path.join(rubicon.config.root_dir, "test-project", "experiments", ".ipynb_checkpoints")
+    )
+    os.makedirs(os.path.join(rubicon.config.root_dir, "test-project", "experiments", "test"))
+
+    assert len(project.experiments()) == 2
+
+
+def test_rubicon_with_misc_files_at_sublevel_level(rubicon_local_filesystem_client_with_project):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    project.log_experiment("exp1")
+    project.log_experiment("exp2")
+
+    Path(os.path.join(rubicon.config.root_dir, "test-project", "experiments", "file.txt")).touch()
+
+    assert len(project.experiments()) == 2
+
+
+def test_rubicon_with_misc_folders_at_deeper_sublevel_level(
+    rubicon_local_filesystem_client_with_project,
+):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    exp = project.log_experiment("exp1")
+    exp.log_parameter("a", 1)
+
+    os.makedirs(
+        os.path.join(
+            rubicon.config.root_dir,
+            "test-project",
+            "experiments",
+            exp.id,
+            "parameters",
+            ".ipynb_checkpoints",
+        )
+    )
+    os.makedirs(
+        os.path.join(
+            rubicon.config.root_dir, "test-project", "experiments", exp.id, "parameters", "test"
+        )
+    )
+
+    assert len(exp.parameters()) == 1

--- a/tests/unit/client/test_dataframe_client.py
+++ b/tests/unit/client/test_dataframe_client.py
@@ -20,4 +20,4 @@ def test_get_data(project_client, test_dataframe):
     df = test_dataframe
     logged_df = parent.log_dataframe(df)
 
-    assert logged_df.data.compute().equals(df.compute())
+    assert logged_df.get_data().compute().equals(df.compute())


### PR DESCRIPTION
closes: #82 

---

## What

As reported in the bug, if misc files sneaked into the `root_dir`, the library and UI would return empty data rather than just skipping the misc file. This was noticed by `.ipynb_checkpoints` folders from experimentation in Lab.

This work handles misc files and folders under the `root_dir` for both the sync and async library. It also updates the async filesystem to leverage [_cat](https://github.com/intake/filesystem_spec/blob/36574204b0f83d3728a447039c9cb16a4019710e/fsspec/asyn.py#L182) from fsspec directly now that it's been updated

## How to Test

Verify tests included handle edge cases and the bug as described in #82 is no longer an issue
