### PR TITLE
82 handle misc dotfiles

### DIFF
--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -38,11 +38,13 @@ class BaseRepository:
 
     def _ls_directories_only(self, path):
         """Returns the names of all the directories at path `path`."""
-        return [
+        directories = [
             os.path.join(p.get("name"), "metadata.json")
             for p in self.filesystem.ls(path, detail=True)
             if p.get("type", p.get("StorageClass")).lower() == "directory"
         ]
+
+        return directories
 
     # -------- Projects --------
 
@@ -89,6 +91,18 @@ class BaseRepository:
 
         return domain.Project(**project)
 
+    def _cat_paths(self, metadata_paths):
+        """Cat `metadata_paths` to get the list of files to include.
+        Ignore FileNotFoundErrors to avoid misc file errors, like hidden
+        dotfiles.
+        """
+        files = []
+        for metadata in self.filesystem.cat(metadata_paths, on_error="return").values():
+            if not isinstance(metadata, FileNotFoundError):
+                files.append(metadata)
+
+        return files
+
     def get_projects(self):
         """Get the list of projects from the filesystem.
 
@@ -101,7 +115,7 @@ class BaseRepository:
             project_metadata_paths = self._ls_directories_only(self.root_dir)
             projects = [
                 domain.Project(**json.loads(metadata))
-                for metadata in self.filesystem.cat(project_metadata_paths).values()
+                for metadata in self._cat_paths(project_metadata_paths)
             ]
         except FileNotFoundError:
             return []
@@ -187,8 +201,8 @@ class BaseRepository:
         try:
             experiment_metadata_paths = self._ls_directories_only(experiment_metadata_root)
             experiments = [
-                domain.Experiment(**json.loads(data))
-                for data in self.filesystem.cat(experiment_metadata_paths).values()
+                domain.Experiment(**json.loads(metadata))
+                for metadata in self._cat_paths(experiment_metadata_paths)
             ]
         except FileNotFoundError:
             return []
@@ -305,8 +319,8 @@ class BaseRepository:
         try:
             artifact_metadata_paths = self._ls_directories_only(artifact_metadata_root)
             artifacts = [
-                domain.Artifact(**json.loads(data))
-                for data in self.filesystem.cat(artifact_metadata_paths).values()
+                domain.Artifact(**json.loads(metadata))
+                for metadata in self._cat_paths(artifact_metadata_paths)
             ]
         except FileNotFoundError:
             return []
@@ -507,8 +521,8 @@ class BaseRepository:
         try:
             dataframe_metadata_paths = self._ls_directories_only(dataframe_metadata_root)
             dataframes = [
-                domain.Dataframe(**json.loads(data))
-                for data in self.filesystem.cat(dataframe_metadata_paths).values()
+                domain.Dataframe(**json.loads(metadata))
+                for metadata in self._cat_paths(dataframe_metadata_paths)
             ]
         except FileNotFoundError:
             return []
@@ -670,8 +684,8 @@ class BaseRepository:
         try:
             feature_metadata_paths = self._ls_directories_only(feature_metadata_root)
             features = [
-                domain.Feature(**json.loads(data))
-                for data in self.filesystem.cat(feature_metadata_paths).values()
+                domain.Feature(**json.loads(metadata))
+                for metadata in self._cat_paths(feature_metadata_paths)
             ]
         except FileNotFoundError:
             return []
@@ -775,8 +789,8 @@ class BaseRepository:
         try:
             metric_metadata_paths = self._ls_directories_only(metric_metadata_root)
             metrics = [
-                domain.Metric(**json.loads(data))
-                for data in self.filesystem.cat(metric_metadata_paths).values()
+                domain.Metric(**json.loads(metadata))
+                for metadata in self._cat_paths(metric_metadata_paths)
             ]
         except FileNotFoundError:
             return []
@@ -879,8 +893,8 @@ class BaseRepository:
         try:
             parameter_metadata_paths = self._ls_directories_only(parameter_metadata_root)
             parameters = [
-                domain.Parameter(**json.loads(data))
-                for data in self.filesystem.cat(parameter_metadata_paths).values()
+                domain.Parameter(**json.loads(metadata))
+                for metadata in self._cat_paths(parameter_metadata_paths)
             ]
         except FileNotFoundError:
             return []

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -44,7 +44,22 @@ class BaseRepository:
             if p.get("type", p.get("StorageClass")).lower() == "directory"
         ]
 
+        # TODO - discuss changing this to ignore directories that have dotfiles in their paths
+        # rather than catching all possible FileNotFound errors
+
         return directories
+
+    def _cat_paths(self, metadata_paths):
+        """Cat `metadata_paths` to get the list of files to include.
+        Ignore FileNotFoundErrors to avoid misc file errors, like hidden
+        dotfiles.
+        """
+        files = []
+        for metadata in self.filesystem.cat(metadata_paths, on_error="return").values():
+            if not isinstance(metadata, FileNotFoundError):
+                files.append(metadata)
+
+        return files
 
     # -------- Projects --------
 
@@ -90,18 +105,6 @@ class BaseRepository:
             raise RubiconException(f"No project with name '{project_name}' found.")
 
         return domain.Project(**project)
-
-    def _cat_paths(self, metadata_paths):
-        """Cat `metadata_paths` to get the list of files to include.
-        Ignore FileNotFoundErrors to avoid misc file errors, like hidden
-        dotfiles.
-        """
-        files = []
-        for metadata in self.filesystem.cat(metadata_paths, on_error="return").values():
-            if not isinstance(metadata, FileNotFoundError):
-                files.append(metadata)
-
-        return files
 
     def get_projects(self):
         """Get the list of projects from the filesystem.

--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 
 import fsspec
@@ -44,9 +45,6 @@ class BaseRepository:
             if p.get("type", p.get("StorageClass")).lower() == "directory"
         ]
 
-        # TODO - discuss changing this to ignore directories that have dotfiles in their paths
-        # rather than catching all possible FileNotFound errors
-
         return directories
 
     def _cat_paths(self, metadata_paths):
@@ -56,7 +54,10 @@ class BaseRepository:
         """
         files = []
         for metadata in self.filesystem.cat(metadata_paths, on_error="return").values():
-            if not isinstance(metadata, FileNotFoundError):
+            if isinstance(metadata, FileNotFoundError):
+                warning = f"{metadata} not found. Was this file unintentionally created?"
+                warnings.warn(warning)
+            else:
                 files.append(metadata)
 
         return files

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -103,6 +103,16 @@ def rubicon_local_filesystem_client():
 
 
 @pytest.fixture
+def rubicon_local_filesystem_client_with_project(rubicon_local_filesystem_client):
+    rubicon = rubicon_local_filesystem_client
+
+    project_name = "Test Project"
+    project = rubicon.get_or_create_project(project_name, description="testing")
+
+    return rubicon, project
+
+
+@pytest.fixture
 def project_client(rubicon_client):
     """Setup an instance of rubicon configured to log to memory
     with a default project and clean it up afterwards.

--- a/tests/integration/test_misc_dotfiles.py
+++ b/tests/integration/test_misc_dotfiles.py
@@ -1,14 +1,13 @@
 import os
-from pathlib import Path
 
 
 def test_rubicon_with_misc_folders_at_project_level(rubicon_local_filesystem_client_with_project):
     rubicon, project = rubicon_local_filesystem_client_with_project
 
-    os.makedirs(os.path.join(rubicon.config.root_dir, "test-project", ".ipynb_checkpoints"))
-    os.makedirs(os.path.join(rubicon.config.root_dir, "test"))
+    os.makedirs(os.path.join(rubicon.config.root_dir, ".ipynb_checkpoints"))
 
     assert len(rubicon.projects()) == 1
+
 
 def test_rubicon_with_misc_folders_at_sublevel_level(rubicon_local_filesystem_client_with_project):
     rubicon, project = rubicon_local_filesystem_client_with_project
@@ -21,6 +20,7 @@ def test_rubicon_with_misc_folders_at_sublevel_level(rubicon_local_filesystem_cl
     )
 
     assert len(project.experiments()) == 2
+
 
 def test_rubicon_with_misc_folders_at_deeper_sublevel_level(
     rubicon_local_filesystem_client_with_project,

--- a/tests/integration/test_misc_dotfiles.py
+++ b/tests/integration/test_misc_dotfiles.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 
 def test_rubicon_with_misc_folders_at_project_level(rubicon_local_filesystem_client_with_project):
@@ -19,7 +20,11 @@ def test_rubicon_with_misc_folders_at_sublevel_level(rubicon_local_filesystem_cl
         os.path.join(rubicon.config.root_dir, "test-project", "experiments", ".ipynb_checkpoints")
     )
 
-    assert len(project.experiments()) == 2
+    with warnings.catch_warnings(record=True) as w:
+        experiments = project.experiments()
+
+        assert len(experiments) == 2
+        assert "not found" in str(w[-1].message)
 
 
 def test_rubicon_with_misc_folders_at_deeper_sublevel_level(

--- a/tests/integration/test_misc_dotfiles.py
+++ b/tests/integration/test_misc_dotfiles.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+
+
+def test_rubicon_with_misc_folders_at_project_level(rubicon_local_filesystem_client_with_project):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    os.makedirs(os.path.join(rubicon.config.root_dir, "test-project", ".ipynb_checkpoints"))
+    os.makedirs(os.path.join(rubicon.config.root_dir, "test"))
+
+    assert len(rubicon.projects()) == 1
+
+def test_rubicon_with_misc_folders_at_sublevel_level(rubicon_local_filesystem_client_with_project):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    project.log_experiment("exp1")
+    project.log_experiment("exp2")
+
+    os.makedirs(
+        os.path.join(rubicon.config.root_dir, "test-project", "experiments", ".ipynb_checkpoints")
+    )
+
+    assert len(project.experiments()) == 2
+
+def test_rubicon_with_misc_folders_at_deeper_sublevel_level(
+    rubicon_local_filesystem_client_with_project,
+):
+    rubicon, project = rubicon_local_filesystem_client_with_project
+
+    exp = project.log_experiment("exp1")
+    exp.log_parameter("a", 1)
+
+    os.makedirs(
+        os.path.join(
+            rubicon.config.root_dir,
+            "test-project",
+            "experiments",
+            exp.id,
+            "parameters",
+            ".ipynb_checkpoints",
+        )
+    )
+
+    assert len(exp.parameters()) == 1

--- a/tests/unit/client/test_dataframe_client.py
+++ b/tests/unit/client/test_dataframe_client.py
@@ -20,4 +20,4 @@ def test_get_data(project_client, test_dataframe):
     df = test_dataframe
     logged_df = parent.log_dataframe(df)
 
-    assert logged_df.data.compute().equals(df.compute())
+    assert logged_df.get_data().compute().equals(df.compute())


### PR DESCRIPTION
closes: #82 

---

## What

As reported in the bug, if misc files sneak into the `root_dir`, the library and UI return empty data rather than just skipping the misc file. This was noticed by `.ipynb_checkpoints` folders from experimentation in Lab.

This handles misc files under the `root_dir` for both the sync library.

## How to Test

Verify tests included handle edge cases and the bug as described in #82 is no longer an issue