### PR TITLE
Handle misc files in async

### DIFF
--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - dask>=2.12.0
   - jupyter-dash
   - pandas>=1.0
-  - fsspec>=0.8.7
+  - fsspec
   - intake>=0.5.2
   - prefect>=0.12.0
   - pyarrow>=0.18.0

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - dask>=2.12.0
   - jupyter-dash
   - pandas>=1.0
-  - fsspec
+  - fsspec>=2021.4.0
   - intake>=0.5.2
   - prefect>=0.12.0
   - pyarrow>=0.18.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - click>=7.1
   - dask>=2.12.0
   - pandas>=1.0
-  - fsspec
+  - fsspec>=2021.4.0
   - intake>=0.5.2
   - pyarrow>=0.18.0
   - pyyaml>=5.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - click>=7.1
   - dask>=2.12.0
   - pandas>=1.0
-  - fsspec>=0.8.7
+  - fsspec
   - intake>=0.5.2
   - pyarrow>=0.18.0
   - pyyaml>=5.4.0

--- a/rubicon/repository/asynchronous/base.py
+++ b/rubicon/repository/asynchronous/base.py
@@ -652,7 +652,7 @@ class AsynchronousBaseRepository(BaseRepository):
         dataframe_metadata_root = self._get_dataframe_metadata_root(project_name, experiment_id)
 
         try:
-            self.filesystem.rm(f"{dataframe_metadata_root}/{dataframe_id}", recursive=True)
+            await self.filesystem._rm(f"{dataframe_metadata_root}/{dataframe_id}", recursive=True)
         except FileNotFoundError:
             raise RubiconException(f"No dataframe with id `{dataframe_id}` found.")
 
@@ -808,7 +808,7 @@ class AsynchronousBaseRepository(BaseRepository):
         artifact_metadata_root = self._get_artifact_metadata_root(project_name, experiment_id)
 
         try:
-            self.filesystem.rm(f"{artifact_metadata_root}/{artifact_id}", recursive=True)
+            await self.filesystem._rm(f"{artifact_metadata_root}/{artifact_id}", recursive=True)
         except FileNotFoundError:
             raise RubiconException(f"No artifact with id `{artifact_id}` found.")
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(pwd, "README.md"), encoding="utf-8") as readme:
 install_requires = [
     "click>=7.1",
     "dask[dataframe]>=2.12.0",
-    "fsspec",
+    "fsspec>=2021.4.0",
     "intake>=0.5.2",
     "pyarrow>=0.18.0",
     "pyyaml>=5.4.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(pwd, "README.md"), encoding="utf-8") as readme:
 install_requires = [
     "click>=7.1",
     "dask[dataframe]>=2.12.0",
-    "fsspec>=0.8.7",
+    "fsspec",
     "intake>=0.5.2",
     "pyarrow>=0.18.0",
     "pyyaml>=5.4.0",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,10 +20,6 @@ def asyn_repo_w_mock_filesystem():
     asyn_repo._persist_domain = AsynchronousMock()
     asyn_repo.filesystem = AsynchronousMock()
 
-    # Necessary because we are using the synchronous `rm` due to some
-    # bugs/missing features in the asynchronous `fsspec._rm_file`.
-    asyn_repo.filesystem.rm = MagicMock()
-
     # Necessary because we are using the synchronous `invalidate_cache`
     # as `fsspec`'s async S3 repo doesn't seem to do it on its own.
     asyn_repo.filesystem.invalidate_cache = MagicMock()

--- a/tests/integration/test_async_rubicon.py
+++ b/tests/integration/test_async_rubicon.py
@@ -117,7 +117,9 @@ def test_rubicon(rubicon, request):
 
         assert len(read_experiment_dataframes) == 1
         assert written_experiment_dataframe.id == read_experiment_dataframes[0].id
-        assert written_experiment_dataframe.data.equals(read_experiment_dataframes[0].data)
+        assert written_experiment_dataframe.get_data().equals(
+            read_experiment_dataframes[0].get_data()
+        )
         assert await written_experiment_dataframe.tags == await read_experiment_dataframes[0].tags
 
         await rubicon.repository.filesystem._rm(rubicon.repository.root_dir, recursive=True)

--- a/tests/integration/test_async_rubicon.py
+++ b/tests/integration/test_async_rubicon.py
@@ -109,7 +109,7 @@ def test_rubicon(rubicon, request):
 
         assert len(read_project_dataframes) == 1
         assert written_project_dataframe.id == read_project_dataframes[0].id
-        assert written_project_dataframe.data.equals(read_project_dataframes[0].data)
+        assert written_project_dataframe.get_data().equals(read_project_dataframes[0].get_data())
         assert await written_project_dataframe.tags == await read_project_dataframes[0].tags
 
         await read_project.delete_dataframes([read_project_dataframes[0].id])

--- a/tests/integration/test_async_rubicon.py
+++ b/tests/integration/test_async_rubicon.py
@@ -109,9 +109,7 @@ def test_rubicon(rubicon, request):
 
         assert len(read_project_dataframes) == 1
         assert written_project_dataframe.id == read_project_dataframes[0].id
-        assert written_project_dataframe.data.compute().equals(
-            read_project_dataframes[0].data.compute()
-        )
+        assert written_project_dataframe.data.equals(read_project_dataframes[0].data)
         assert await written_project_dataframe.tags == await read_project_dataframes[0].tags
 
         await read_project.delete_dataframes([read_project_dataframes[0].id])
@@ -119,12 +117,10 @@ def test_rubicon(rubicon, request):
 
         assert len(read_experiment_dataframes) == 1
         assert written_experiment_dataframe.id == read_experiment_dataframes[0].id
-        assert written_experiment_dataframe.data.compute().equals(
-            read_experiment_dataframes[0].data.compute()
-        )
+        assert written_experiment_dataframe.data.equals(read_experiment_dataframes[0].data)
         assert await written_experiment_dataframe.tags == await read_experiment_dataframes[0].tags
 
-        rubicon.repository.filesystem.rm(rubicon.repository.root_dir, recursive=True)
+        await rubicon.repository.filesystem._rm(rubicon.repository.root_dir, recursive=True)
         await rubicon.repository.filesystem._s3.close()
 
     if "change-me" in rubicon.repository.root_dir:
@@ -135,4 +131,5 @@ def test_rubicon(rubicon, request):
 
         rubicon.repository.root_dir = root_dir
 
-    asyncio.run(_test_rubicon(rubicon))
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_test_rubicon(rubicon))

--- a/tests/unit/repository/asynchronous/test_asyn_base_repo.py
+++ b/tests/unit/repository/asynchronous/test_asyn_base_repo.py
@@ -71,9 +71,10 @@ def test_get_projects(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._ls.return_value = [
         {"name": path, "StorageClass": "DIRECTORY"} for path in project_dirs
     ]
-    asyn_repo_w_mock_filesystem.filesystem._cat_file.side_effect = [
-        json.dumps(e) for e in written_projects
-    ]
+
+    mock_cat = MagicMock()
+    mock_cat.values.return_value = [json.dumps(p) for p in written_projects]
+    asyn_repo_w_mock_filesystem.filesystem._cat.return_value = mock_cat
 
     projects = asyncio.run(asyn_repo_w_mock_filesystem.get_projects())
 
@@ -161,9 +162,9 @@ def test_get_experiments(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._ls.return_value = [
         {"name": path, "StorageClass": "DIRECTORY"} for path in experiment_dirs
     ]
-    asyn_repo_w_mock_filesystem.filesystem._cat_file.side_effect = [
-        json.dumps(e) for e in written_experiments
-    ]
+    mock_cat = MagicMock()
+    mock_cat.values.return_value = [json.dumps(e) for e in written_experiments]
+    asyn_repo_w_mock_filesystem.filesystem._cat.return_value = mock_cat
 
     experiments = asyncio.run(asyn_repo_w_mock_filesystem.get_experiments(project.name))
 
@@ -271,9 +272,9 @@ def test_get_features(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._ls.return_value = [
         {"name": path, "StorageClass": "DIRECTORY"} for path in feature_dirs
     ]
-    asyn_repo_w_mock_filesystem.filesystem._cat_file.side_effect = [
-        json.dumps(f) for f in written_features
-    ]
+    mock_cat = MagicMock()
+    mock_cat.values.return_value = [json.dumps(f) for f in written_features]
+    asyn_repo_w_mock_filesystem.filesystem._cat.return_value = mock_cat
 
     features = asyncio.run(
         asyn_repo_w_mock_filesystem.get_features(experiment.project_name, experiment.id)
@@ -390,9 +391,9 @@ def test_get_parameters(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._ls.return_value = [
         {"name": path, "StorageClass": "DIRECTORY"} for path in parameter_dirs
     ]
-    asyn_repo_w_mock_filesystem.filesystem._cat_file.side_effect = [
-        json.dumps(p) for p in written_parameters
-    ]
+    mock_cat = MagicMock()
+    mock_cat.values.return_value = [json.dumps(p) for p in written_parameters]
+    asyn_repo_w_mock_filesystem.filesystem._cat.return_value = mock_cat
 
     parameters = asyncio.run(
         asyn_repo_w_mock_filesystem.get_parameters(experiment.project_name, experiment.id)
@@ -504,9 +505,9 @@ def test_get_metrics(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._ls.return_value = [
         {"name": path, "StorageClass": "DIRECTORY"} for path in metric_dirs
     ]
-    asyn_repo_w_mock_filesystem.filesystem._cat_file.side_effect = [
-        json.dumps(m) for m in written_metrics
-    ]
+    mock_cat = MagicMock()
+    mock_cat.values.return_value = [json.dumps(m) for m in written_metrics]
+    asyn_repo_w_mock_filesystem.filesystem._cat.return_value = mock_cat
 
     metrics = asyncio.run(
         asyn_repo_w_mock_filesystem.get_metrics(experiment.project_name, experiment.id)
@@ -598,9 +599,9 @@ def test_get_artifacts_metadata(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._ls.return_value = [
         {"name": path, "StorageClass": "DIRECTORY"} for path in artifact_dirs
     ]
-    asyn_repo_w_mock_filesystem.filesystem._cat_file.side_effect = [
-        json.dumps(a) for a in written_artifacts
-    ]
+    mock_cat = MagicMock()
+    mock_cat.values.return_value = [json.dumps(a) for a in written_artifacts]
+    asyn_repo_w_mock_filesystem.filesystem._cat.return_value = mock_cat
 
     artifacts = asyncio.run(asyn_repo_w_mock_filesystem.get_artifacts_metadata(project.name))
 
@@ -740,9 +741,9 @@ def test_get_dataframes_metadata(asyn_repo_w_mock_filesystem):
     asyn_repo_w_mock_filesystem.filesystem._ls.return_value = [
         {"name": path, "StorageClass": "DIRECTORY"} for path in dataframe_dirs
     ]
-    asyn_repo_w_mock_filesystem.filesystem._cat_file.side_effect = [
-        json.dumps(d) for d in written_dataframes
-    ]
+    mock_cat = MagicMock()
+    mock_cat.values.return_value = [json.dumps(d) for d in written_dataframes]
+    asyn_repo_w_mock_filesystem.filesystem._cat.return_value = mock_cat
 
     dataframes = asyncio.run(asyn_repo_w_mock_filesystem.get_dataframes_metadata(project.name))
 

--- a/tests/unit/repository/asynchronous/test_asyn_base_repo.py
+++ b/tests/unit/repository/asynchronous/test_asyn_base_repo.py
@@ -655,13 +655,13 @@ def test_delete_artifact(asyn_repo_w_mock_filesystem):
 
     asyncio.run(asyn_repo_w_mock_filesystem.delete_artifact(project.name, artifact.id))
 
-    filesystem_expected = [call.rm(artifact_dir, recursive=True), call.invalidate_cache()]
+    filesystem_expected = [call._rm(artifact_dir, recursive=True), call.invalidate_cache()]
 
     assert asyn_repo_w_mock_filesystem.filesystem.mock_calls == filesystem_expected
 
 
 def test_delete_artifact_throws_error_if_not_found(asyn_repo_w_mock_filesystem):
-    asyn_repo_w_mock_filesystem.filesystem.rm.side_effect = FileNotFoundError()
+    asyn_repo_w_mock_filesystem.filesystem._rm.side_effect = FileNotFoundError()
 
     project = domain.Project(f"Test Project {uuid.uuid4()}")
     missing_artifact_id = uuid.uuid4()
@@ -772,13 +772,13 @@ def test_delete_dataframe(asyn_repo_w_mock_filesystem):
 
     asyncio.run(asyn_repo_w_mock_filesystem.delete_dataframe(project.name, dataframe.id))
 
-    filesystem_expected = [call.rm(dataframe_dir, recursive=True), call.invalidate_cache()]
+    filesystem_expected = [call._rm(dataframe_dir, recursive=True), call.invalidate_cache()]
 
     assert asyn_repo_w_mock_filesystem.filesystem.mock_calls == filesystem_expected
 
 
 def test_delete_dataframe_throws_error_if_not_found(asyn_repo_w_mock_filesystem):
-    asyn_repo_w_mock_filesystem.filesystem.rm.side_effect = FileNotFoundError()
+    asyn_repo_w_mock_filesystem.filesystem._rm.side_effect = FileNotFoundError()
 
     project = domain.Project(f"Test Project {uuid.uuid4()}")
     missing_dataframe_id = uuid.uuid4()


### PR DESCRIPTION
closes: #88 

---

## What

Handles the misc file issue in the asyn library. Also upgrades `fsspec` and updates `rm` and `cat` to use their asyn counterparts now that they have been released in latest version of `fsspec`

## How to Test

Run the asyn integration tests locally
