### PR TITLE
pytest warnings quickfix

### DIFF
--- a/rubicon/repository/base.py
+++ b/rubicon/repository/base.py
@@ -53,9 +53,9 @@ class BaseRepository:
         dotfiles.
         """
         files = []
-        for metadata in self.filesystem.cat(metadata_paths, on_error="return").values():
+        for path, metadata in self.filesystem.cat(metadata_paths, on_error="return").items():
             if isinstance(metadata, FileNotFoundError):
-                warning = f"{metadata} not found. Was this file unintentionally created?"
+                warning = f"{path} not found. Was this file unintentionally created?"
                 warnings.warn(warning)
             else:
                 files.append(metadata)

--- a/tests/integration/test_misc_dotfiles.py
+++ b/tests/integration/test_misc_dotfiles.py
@@ -7,7 +7,11 @@ def test_rubicon_with_misc_folders_at_project_level(rubicon_local_filesystem_cli
 
     os.makedirs(os.path.join(rubicon.config.root_dir, ".ipynb_checkpoints"))
 
-    assert len(rubicon.projects()) == 1
+    with warnings.catch_warnings(record=True) as w:
+        projects = rubicon.projects()
+
+        assert len(projects) == 1
+        assert "not found" in str(w[-1].message)
 
 
 def test_rubicon_with_misc_folders_at_sublevel_level(rubicon_local_filesystem_client_with_project):
@@ -46,4 +50,8 @@ def test_rubicon_with_misc_folders_at_deeper_sublevel_level(
         )
     )
 
-    assert len(exp.parameters()) == 1
+    with warnings.catch_warnings(record=True) as w:
+        parameters = exp.parameters()
+
+        assert len(parameters) == 1
+        assert "not found" in str(w[-1].message)

--- a/tests/integration/test_prefect_flow.py
+++ b/tests/integration/test_prefect_flow.py
@@ -92,7 +92,7 @@ def test_flow():
     dataframes = experiment.dataframes()
     assert len(dataframes) == 1
     assert dataframes[0].description == "a test df"
-    assert df.equals(dataframes[0].data)
+    assert df.equals(dataframes[0].get_data())
 
     # artifacts
     artifacts = experiment.artifacts()

--- a/tests/integration/test_rubicon.py
+++ b/tests/integration/test_rubicon.py
@@ -94,7 +94,7 @@ def test_rubicon(rubicon, request):
     read_project_dataframes = read_project.dataframes()
     assert len(read_project_dataframes) == 1
     assert written_project_dataframe.id == read_project_dataframes[0].id
-    assert written_project_dataframe.data.equals(read_project_dataframes[0].data)
+    assert written_project_dataframe.get_data().equals(read_project_dataframes[0].get_data())
     assert written_project_dataframe.tags == read_project_dataframes[0].tags
 
     read_project.delete_dataframes([read_project_dataframes[0].id])


### PR DESCRIPTION
## What
  * fixes the warnings coming from rubicon in the tests
  * the ones that are left are thrown when `prefect` is imported in the tests
    * no idea why - importing `prefect` from an interpreter doesn't throw anything

## How to Test
  * `python -m pytest`
